### PR TITLE
update readme, add script for running ui + server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           key: dependencies-{{ checksum "package.json" }}
 
       # build
-      - run: yarn build:anchor-tests
+      - run: yarn build:all
 
       - persist_to_workspace:
           root: ~/repo

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is a container for three applications
 - [ui](./ui)
 	- A [react-redux](https://react-redux.js.org/) web interface for running anchor tests. Connects to the server via websockets.
 - [server](./server)
-	- An [socket.io](socket.io) server. Depends on `@stellar/anchor-tests`.
+	- A [socket.io](socket.io) server. Depends on `@stellar/anchor-tests`.
 
 See each project for more information. To install and run all applications:
 


### PR DESCRIPTION
Add a `yarn build:all` and `yarn start:all` command for running the entire project. Updates README. Requires `yarn build:all` to succeed for CircleCI check to pass.