### PR TITLE
Add makefiles for jenkins jobs

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -1,0 +1,15 @@
+# Check if we need to prepend docker commands with sudo
+SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
+
+# If LABEL is not provided set default value
+LABEL ?= $(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+# If TAG is not provided set default value
+TAG ?= stellar/stellar-anchor-tests:$(LABEL)
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+
+docker-build:
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" -t $(TAG) .
+
+docker-push:
+	$(SUDO) docker push $(TAG)

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,0 +1,15 @@
+# Check if we need to prepend docker commands with sudo
+SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
+
+# If LABEL is not provided set default value
+LABEL ?= $(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
+# If TAG is not provided set default value
+TAG ?= stellar/stellar-anchor-tests:$(LABEL)
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+
+docker-build:
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" -t $(TAG) .
+
+docker-push:
+	$(SUDO) docker push $(TAG)


### PR DESCRIPTION
Adding makefiles for each docker image that needs to be built. This should be the last step for enabling previews in our PR assuming the rest of the configuration files are written properly.