### PR TITLE
track progress of run tests as results come in from api

### DIFF
--- a/ui/src/components/TestCases/SepGroupTracker.tsx
+++ b/ui/src/components/TestCases/SepGroupTracker.tsx
@@ -1,10 +1,10 @@
 export const SepGroupTracker: React.FC<{
-  currentlyRunning: number;
+  testsCompleted: number;
   testsTotal: number;
-}> = ({ currentlyRunning, testsTotal }) => {
+}> = ({ testsCompleted, testsTotal }) => {
   return (
     <>
-      Running {currentlyRunning} of {testsTotal}...
+      Running {testsCompleted} of {testsTotal}...
     </>
   );
 };

--- a/ui/src/components/TestCases/SepGroupTracker.tsx
+++ b/ui/src/components/TestCases/SepGroupTracker.tsx
@@ -1,0 +1,10 @@
+export const SepGroupTracker: React.FC<{
+  currentlyRunning: number;
+  testsTotal: number;
+}> = ({ currentlyRunning, testsTotal }) => {
+  return (
+    <>
+      Running {currentlyRunning} of {testsTotal}...
+    </>
+  );
+};

--- a/ui/src/components/TestCases/index.tsx
+++ b/ui/src/components/TestCases/index.tsx
@@ -2,60 +2,47 @@ import React from "react";
 import styled from "styled-components";
 
 import { getTestRunId } from "helpers/testCases";
-import { TestCase } from "types/testCases";
+import { GroupedTestCases, TestCase } from "types/testCases";
 import { SepBlock } from "../SepBlock";
+import { SepGroupTracker } from "./SepGroupTracker";
 import { TestBlock } from "../TestBlock";
 
 export const SepUIOrder = [1, 10, 12, 6, 24, 31];
-
-type GroupedTestCases = { sep: number; tests: TestCase[] }[];
 
 const TestCasesWrapper = styled.section`
   margin-top: 2rem;
 `;
 
-function groupBySep(testRuns: TestCase[]): GroupedTestCases {
-  const groupedTestRuns = [];
-  let currentSep;
-  for (const testRun of testRuns) {
-    if (Number(testRun.test.sep) !== currentSep) {
-      currentSep = Number(testRun.test.sep);
-      groupedTestRuns.push({
-        sep: currentSep,
-        tests: [] as TestCase[],
-      });
-    }
-    const sepGroup = groupedTestRuns[groupedTestRuns.length - 1];
-    sepGroup.tests.push(testRun);
-  }
-  return groupedTestRuns;
-}
-
-export const TestCases: React.FC<{ testCases: TestCase[] }> = ({
+export const TestCases: React.FC<{ testCases: GroupedTestCases }> = ({
   testCases,
-}) => {
-  const groupedTestCases = groupBySep(testCases);
-  return (
-    <>
-      <TestCasesWrapper>
-        {groupedTestCases.map(
-          (sepGroup: { sep: number; tests: TestCase[] }) => {
-            return (
-              <div key={`sep-${sepGroup.sep}-tests`}>
-                <SepBlock sep={sepGroup.sep}></SepBlock>
-                {sepGroup.tests.map((testCase: TestCase) => {
-                  return (
-                    <TestBlock
-                      key={getTestRunId(testCase.test)}
-                      testCase={testCase}
-                    ></TestBlock>
-                  );
-                })}
-              </div>
-            );
-          },
-        )}
-      </TestCasesWrapper>
-    </>
-  );
-};
+}) => (
+  <>
+    <TestCasesWrapper>
+      {testCases.map(
+        (sepGroup: {
+          progress: { running: number; total: number };
+          sep: number;
+          tests: TestCase[];
+        }) => {
+          return (
+            <div key={`sep-${sepGroup.sep}-tests`}>
+              <SepBlock sep={sepGroup.sep}></SepBlock>
+              <SepGroupTracker
+                currentlyRunning={sepGroup.progress.running}
+                testsTotal={sepGroup.progress.total}
+              />
+              {sepGroup.tests.map((testCase: TestCase) => {
+                return (
+                  <TestBlock
+                    key={getTestRunId(testCase.test)}
+                    testCase={testCase}
+                  ></TestBlock>
+                );
+              })}
+            </div>
+          );
+        },
+      )}
+    </TestCasesWrapper>
+  </>
+);

--- a/ui/src/components/TestCases/index.tsx
+++ b/ui/src/components/TestCases/index.tsx
@@ -20,7 +20,7 @@ export const TestCases: React.FC<{ testCases: GroupedTestCases }> = ({
     <TestCasesWrapper>
       {testCases.map(
         (sepGroup: {
-          progress: { running: number; total: number };
+          progress: { completed: number; total: number };
           sep: number;
           tests: TestCase[];
         }) => {
@@ -28,7 +28,7 @@ export const TestCases: React.FC<{ testCases: GroupedTestCases }> = ({
             <div key={`sep-${sepGroup.sep}-tests`}>
               <SepBlock sep={sepGroup.sep}></SepBlock>
               <SepGroupTracker
-                currentlyRunning={sepGroup.progress.running}
+                testsCompleted={sepGroup.progress.completed}
                 testsTotal={sepGroup.progress.total}
               />
               {sepGroup.tests.map((testCase: TestCase) => {

--- a/ui/src/types/testCases.ts
+++ b/ui/src/types/testCases.ts
@@ -2,3 +2,9 @@ export interface TestCase {
   test: any; // Test from @stellar/anchor-tests
   result?: any; // Result from @stellar/anchor-tests
 }
+
+export type GroupedTestCases = {
+  progress: { running: number; total: number };
+  sep: number;
+  tests: TestCase[];
+}[];

--- a/ui/src/types/testCases.ts
+++ b/ui/src/types/testCases.ts
@@ -4,7 +4,7 @@ export interface TestCase {
 }
 
 export type GroupedTestCases = {
-  progress: { running: number; total: number };
+  progress: { completed: number; total: number };
   sep: number;
   tests: TestCase[];
 }[];


### PR DESCRIPTION
The purpose of this PR is to capture the progress of how many tests have been run for each sep as the results are coming in. 

With the old model, we needed to to continuously iterate over each sep group in <TestCases /> to calculate how many tests of each sep had been completed. This was causing a lot of re-rendering and was pretty inefficient. 

The solution proposed here is to capture how many tests are "done" as we collect the results in the "runTests" callback. This lets us collect all data from the results in one place.

This also has the added benefit of simplifying `<TestCases />`. Before, it was grouping `testRunArray` by sep group on every render. We, however, we were never using `testRunArray` for any purpose other than feeding it to `<TestCases />` to be coerced into a usable map. Rather than saving `testRunArray` in state at all, we now do the transformation from `testRunArray` -> `GroupedTestCases` right away. This creates one source of truth for test case data that includes all results and progress info