### PR TITLE
nginx: use stick sessions

### DIFF
--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -1,3 +1,8 @@
+upstream backend {
+    ip_hash;
+    server localhost:8000;
+}
+
 server {
     listen       80;
     server_name  localhost;
@@ -20,7 +25,7 @@ server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $host;
 
-      proxy_pass http://localhost:8000;
+      proxy_pass http://backend;
 
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
In our production deployment we'll have two servers running, which means we need to ensure websocket connections remain on the same host for the duration of the session.