### PR TITLE
add health check endpoint to server

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,8 +15,8 @@ const app = express();
 const httpServer = createServer(app);
 const io = new Server(httpServer, { path: "/api", cors: { origin: "*" } });
 
-app.get("/api", (_req, res) => {
-  res.send("Hello World!");
+app.get("/health", (_req, res) => {
+  res.json({ status: "up" });
 });
 
 io.on("connection", (socket: Socket) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,7 +15,7 @@ const app = express();
 const httpServer = createServer(app);
 const io = new Server(httpServer, { path: "/api", cors: { origin: "*" } });
 
-app.get("/health", (_req, res) => {
+app.get("/api/health", (_req, res) => {
   res.json({ status: "up" });
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,7 +15,7 @@ const app = express();
 const httpServer = createServer(app);
 const io = new Server(httpServer, { path: "/api", cors: { origin: "*" } });
 
-app.get("/api/health", (_req, res) => {
+app.get("/health", (_req, res) => {
   res.json({ status: "up" });
 });
 

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -16,6 +16,13 @@ server {
         gzip_static on;
     }
 
+    location /health {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $host;
+
+      proxy_pass http://localhost:8000;
+    }
+
     location /api {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $host;


### PR DESCRIPTION
relates to stellar/kube#544

Adds a `GET /api/health` endpoint for kubernetes to use when determining if the service is up and ready to begin serving requests.

We're putting the `/health` endpoint under `/api` so the proxy server sends the request to the server container.