### PR TITLE
Bug: check json format of config file and send assetCode in form data

### DIFF
--- a/ui/src/components/TestRunner/index.tsx
+++ b/ui/src/components/TestRunner/index.tsx
@@ -293,9 +293,10 @@ export const TestRunner = () => {
         try {
           sepConfigObj = JSON.parse(e?.target?.result as string);
         } catch {
-          setServerFailure("Unable to parse config file JSON.");
+          setServerFailure("Unable to parse config file JSON. Try correcting the format using a validator.");
           return;
         }
+        setServerFailure("");
         setFormData({
           ...formData,
           sepConfig: sepConfigObj

--- a/ui/src/components/TestRunner/index.tsx
+++ b/ui/src/components/TestRunner/index.tsx
@@ -191,8 +191,6 @@ export const TestRunner = () => {
   const handleSubmit = () => {
     clearTestResults();
     setRunState(RunState.running);
-    console.log("emmitting runTests");
-    console.log(formData);
     socket.emit("runTests", formData, (error: Error) => {
       setServerFailure(
         `server failure occurred: ${error.name}: ${error.message}`,


### PR DESCRIPTION
The config file I was using wasn't properly formatted but the appropriate error was not shown. Additionally, we were not setting the `assetCode` attribute of the form data sent to the server when asset codes are initially fetched.