### PR TITLE
Validate the URL and show error if invalid

### DIFF
--- a/ui/src/components/TestRunnerFields/HomeDomainField.tsx
+++ b/ui/src/components/TestRunnerFields/HomeDomainField.tsx
@@ -57,7 +57,13 @@ export const HomeDomainField = ({
 
   // make toml requests at most once every 250 milliseconds
   const getToml = async (homeDomain: string) => {
-    const homeDomainHost = new URL(homeDomain).host;
+    let homeDomainHost;
+    try {
+      homeDomainHost = new URL(homeDomain).host;
+    } catch {
+      setServerFailure("Invalid URL");
+      return;
+    }
     let tomlObj;
     try {
       tomlObj = await StellarTomlResolver.resolve(homeDomainHost);


### PR DESCRIPTION
If you click "Fetch Stellar Info File" button while the field is empty, a error page is shown:
<img width="731" alt="Screen Shot 2021-07-01 at 11 26 35 AM" src="https://user-images.githubusercontent.com/10968980/124172877-345a1800-da5f-11eb-9794-078f2d1ab966.png">