### PR TITLE
Only send SEP-12 request body to server, don't include 'url' and 'header' attributes

### DIFF
--- a/@stellar/anchor-tests/src/helpers/sep12.ts
+++ b/@stellar/anchor-tests/src/helpers/sep12.ts
@@ -22,7 +22,7 @@ export function makeSep12Request(requestData: any): Request {
       }
     }
   } else {
-    requestBody = JSON.stringify(requestData);
+    requestBody = JSON.stringify(requestData.data);
     requestData.headers["Content-Type"] = "application/json";
   }
   return new Request(requestData.url, {


### PR DESCRIPTION
This bug was indirectly causing the UI to show an error page, although I'm not sure why. During the debug process I noticed the request body of the "create a customer" SEP-12 test included 'url' and 'header' attributes, which lead me to this bug. After fixing, all SEP-12 tests passed and no error page was displayed.