### PR TITLE
Render body as JSON component instead of passing an object as a child element

### DIFF
--- a/ui/src/components/ResultBlock/index.tsx
+++ b/ui/src/components/ResultBlock/index.tsx
@@ -108,23 +108,35 @@ export const ResultBlock: React.FC<{ result: Result }> = ({ result }) => {
                   <div>Request:</div>
                   <LogIndent>
                     {networkCall.request.method} {networkCall.request.url}
-                    <div>Headers:</div>
-                    <LogIndent>
-                      {Object.entries(networkCall.request.headers || []).map(
-                        ([headerKey, headerVal]) => (
-                          <HeaderBlock
-                            headerKey={headerKey}
-                            headerVal={headerVal.toString()}
-                            key={`${headerKey}-${headerVal}`}
-                          />
-                        ),
-                      )}
-                    </LogIndent>
-                  </LogIndent>
-
-                  <div>Body:</div>
-                  <LogIndent>
-                    <Json collapsed src={networkCall.request.body} />
+                    {Object.keys(networkCall.request.headers).length && (
+                      <>
+                        <div>Headers:</div>
+                        <LogIndent>
+                          {Object.entries(networkCall.request.headers || []).map(
+                            ([headerKey, headerVal]) => (
+                              <HeaderBlock
+                                headerKey={headerKey}
+                                headerVal={headerVal.toString()}
+                                key={`${headerKey}-${headerVal}`}
+                              />
+                            ),
+                          )}
+                        </LogIndent>
+                      </>
+                    )}
+                    {networkCall.request.body && (
+                      <>
+                        <div>Body:</div>
+                        <LogIndent>
+                          {typeof networkCall.request.body === "object" && (
+                            <Json collapsed src={networkCall.request.body} />
+                          )}
+                          {typeof networkCall.request.body !== "object" && (
+                            networkCall.request.body
+                          )}
+                        </LogIndent>
+                      </>
+                    )}
                   </LogIndent>
                 </>
               )}
@@ -134,20 +146,26 @@ export const ResultBlock: React.FC<{ result: Result }> = ({ result }) => {
                   <div>Response:</div>
                   <LogIndent>
                     <div>Status Code: {networkCall.response.status}</div>
-                    <div>Headers:</div>
-                    <LogIndent>
-                      {Object.entries(networkCall.response.headers || []).map(
-                        ([headerKey, headerVal]) => (
-                          <HeaderBlock
-                            headerKey={headerKey}
-                            headerVal={headerVal}
-                            key={`${headerKey}-${headerVal}`}
-                          />
-                        ),
-                      )}
-                    </LogIndent>
+                    {Object.keys(networkCall.response.headers).length && (
+                      <>
+                        <div>Headers:</div>
+                        <LogIndent>
+                          {Object.entries(networkCall.response.headers || []).map(
+                            ([headerKey, headerVal]) => (
+                              <HeaderBlock
+                                headerKey={headerKey}
+                                headerVal={headerVal}
+                                key={`${headerKey}-${headerVal}`}
+                              />
+                            ),
+                          )}
+                        </LogIndent>
+                      </>
+                    )}
                     <div>Body:</div>
-                    <LogIndent>{networkCall.response.body}</LogIndent>
+                    <LogIndent>
+                      <Json collapsed src={networkCall.response.body} />
+                    </LogIndent>
                   </LogIndent>
                 </>
               )}


### PR DESCRIPTION
Fixes a bug that causes the UI to crash, and adjusts the indentation of the network call content for a failed test.

While I was working on it, I noticed two other issues:
- While the length of the content window increases and decreases dynamically when opening/closing JSON objects, the initial length can sometimes be too short for requests with many headers
- Our `<ReactJson />` component fails to render response bodies from horizion and friendbot because they're technically `application/hal+json`. The content displayed instead is an error message.

I'll file issues for both of these. 