### PR TITLE
@stellar/anchor-tests: fix CyclicDependency false positive

### DIFF
--- a/@stellar/anchor-tests/src/helpers/test.ts
+++ b/@stellar/anchor-tests/src/helpers/test.ts
@@ -174,6 +174,7 @@ async function* runTestsRecur(
         )) {
           yield testRun;
           if (testRun.result.failure) {
+            chain.pop();
             throw new FailedDependencyError(testRun.test);
           }
         }
@@ -189,6 +190,7 @@ async function* runTestsRecur(
           failedDependencyError = error;
         } else {
           // unexpected exception
+          chain.pop();
           throw error;
         }
       }


### PR DESCRIPTION
The test dependency chain maintained to detect cyclic dependency errors was not properly maintained when failures or exceptions occur for test dependencies. Popping the latest element in these cases resolves the issue.

We'll need to release a new version of the test suite library after merging.