### PR TITLE
Always mark ran tests

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
I found another issue where failed tests wouldn't be added to the `ranTests` object, which is what is used to determine if a test has already run. Omitting tests caused them to remain in the dependency chain list and cause false positive detections of cycles.