### PR TITLE
fix same account different memos test condition

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep12/putCustomer.ts
+++ b/@stellar/anchor-tests/src/tests/sep12/putCustomer.ts
@@ -274,7 +274,7 @@ export const differentMemosSameAccount: Test = {
         !config.sepConfig["12"].customers[
           config.sepConfig["12"].sameAccountDifferentMemos[0]
         ] ||
-        config.sepConfig["12"].customers[
+        !config.sepConfig["12"].customers[
           config.sepConfig["12"].sameAccountDifferentMemos[1]
         ]
       ) {


### PR DESCRIPTION
The SEP-12 test "memos differentiate customers registered by the same account" had a bug when checking the configuration needed for the test, causing the test to fail.