### PR TITLE
Customer File Upload Support

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn pretty-quick --staged --pattern "**/*.ts"
+yarn pretty-quick --staged --pattern "**/*.ts*"

--- a/@stellar/anchor-tests/src/helpers/sep12.ts
+++ b/@stellar/anchor-tests/src/helpers/sep12.ts
@@ -8,14 +8,24 @@ export function makeSep12Request(requestData: any): Request {
   if (hasBinaryFields(requestData.data)) {
     requestBody = new FormData();
     for (const key in requestData.data) {
-      if (requestData.data[key] instanceof ReadStream) {
-        const stats = statSync(requestData.data[key].path);
-        requestBody.append(key, requestData.data[key], {
+      if (
+        typeof requestData.data[key] === "object" &&
+        requestData.data[key].data instanceof ReadStream
+      ) {
+        const stats = statSync(requestData.data[key].data.path);
+        requestBody.append(key, requestData.data[key].data, {
           knownLength: stats.size,
+          contentType: requestData.data[key].contentType,
+          filename: requestData.data[key].fileName,
         });
-      } else if (requestData.data[key] instanceof Buffer) {
-        requestBody.append(key, requestData.data[key], {
-          knownLength: requestData.data[key].length,
+      } else if (
+        typeof requestData.data[key] === "object" &&
+        requestData.data[key].data instanceof Buffer
+      ) {
+        requestBody.append(key, requestData.data[key].data, {
+          knownLength: requestData.data[key].data.length,
+          contentType: requestData.data[key].contentType,
+          filename: requestData.data[key].fileName,
         });
       } else {
         requestBody.append(key, requestData.data[key]);

--- a/@stellar/anchor-tests/src/tests/sep10/tests.ts
+++ b/@stellar/anchor-tests/src/tests/sep10/tests.ts
@@ -529,7 +529,6 @@ const returnsValidChallengeResponse: Test = {
       Buffer.from(firstOpDataValue.toString(), "base64").length !== 48
     ) {
       result.failure = makeFailure(this.failureModes.INVALID_FIRST_OP_VALUE);
-      if (firstOpDataValue) console.log(firstOpDataValue.length);
       return result;
     }
     let webAuthDomainOp;

--- a/ui/src/components/ConfigModalContent/index.tsx
+++ b/ui/src/components/ConfigModalContent/index.tsx
@@ -7,50 +7,73 @@ export const ConfigModalContent: React.FC = () => (
     <Modal.Heading>Configuration Files</Modal.Heading>
     <Modal.Body>
       <p>
-        Configuration files are required for running SEP-6, 12, and 31 tests. 
-        These files provide information required for the test suite to interact with your anchor service properly.
+        Configuration files are required for running SEP-6, 12, and 31 tests.
+        These files provide information required for the test suite to interact
+        with your anchor service properly.
       </p>
       <p>
-        Configuration files are JSON-formatted and have top-level keys for each SEP for which tests are run.
+        Configuration files are JSON-formatted and have top-level keys for each
+        SEP for which tests are run.
       </p>
-      <Json src={{
-        "6": {},
-        "12": {},
-        "31": {}
-      }}></Json>
-      <p>
-        The formats for each SEP are outlined below.
-      </p>
+      <Json
+        src={{
+          "6": {},
+          "12": {},
+          "31": {},
+        }}
+      ></Json>
+      <p>The formats for each SEP are outlined below.</p>
 
       <Heading4>SEP-6</Heading4>
       <p>
-        SEP-6 configuration objects are used for specifying the URL parameters that should be included to GET /deposit and GET /withdraw requests.
+        SEP-6 configuration objects are used for specifying the URL parameters
+        that should be included to GET /deposit and GET /withdraw requests.
       </p>
-      <Json src={{
-        "deposit": {
-          "transactionFields": {}
-        },
-        "withdraw": {
-          "types": {
-            "bank_account (example)": {
-              "transactionFields": {}
-            }
-          }
-        }
-      }}></Json>
+      <Json
+        src={{
+          deposit: {
+            transactionFields: {},
+          },
+          withdraw: {
+            types: {
+              "bank_account (example)": {
+                transactionFields: {},
+              },
+            },
+          },
+        }}
+      ></Json>
       <ul>
         <li>
           <strong>deposit</strong>: contains a single “transactionFields” key
           <ul>
-            <li><strong>transactionFields</strong>: contains the key-value pairs to use as parameters to GET /deposit requests. These items should correspond directly to the items outlined in GET /info’s <TextLink href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#for-each-deposit-asset-response-contains">fields</TextLink> object</li>
+            <li>
+              <strong>transactionFields</strong>: contains the key-value pairs
+              to use as parameters to GET /deposit requests. These items should
+              correspond directly to the items outlined in GET /info’s{" "}
+              <TextLink href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#for-each-deposit-asset-response-contains">
+                fields
+              </TextLink>{" "}
+              object
+            </li>
           </ul>
         </li>
         <li>
           <strong>withdraw</strong>: contains a single “types” key
           <ul>
-            <li><strong>types</strong>: an object containing key-value pairs corresponding directly to GET /info’s <TextLink href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#for-each-withdrawal-asset-response-contains">types</TextLink> object. Currently, only the first type object specified is used.</li>
+            <li>
+              <strong>types</strong>: an object containing key-value pairs
+              corresponding directly to GET /info’s{" "}
+              <TextLink href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#for-each-withdrawal-asset-response-contains">
+                types
+              </TextLink>{" "}
+              object. Currently, only the first type object specified is used.
+            </li>
             <ul>
-              <li><strong>transactionFields</strong>: contains the key-value pairs to use as parameters to GET /withdraw requests for “type”.</li>
+              <li>
+                <strong>transactionFields</strong>: contains the key-value pairs
+                to use as parameters to GET /withdraw requests for “type”.
+              </li>
             </ul>
           </ul>
         </li>
@@ -58,65 +81,113 @@ export const ConfigModalContent: React.FC = () => (
 
       <Heading4>SEP-12</Heading4>
       <p>
-        SEP-12 configuration objects are used for specifying the customer data that should be used when making PUT /customer requests. Currently, binary data is not supported.
+        SEP-12 configuration objects are used for specifying the customer data
+        that should be used when making PUT /customer requests.
       </p>
-      <Json src={{
-        "customers": {
-          "toBeCreated": {
-            "first_name": "John",
-            "last_name": "Doe",
-            "email_address": "joe@email.com",
-            "bank_number": "123",
-            "bank_account_number": "123",
-          },
-          "sendingClient": {
-            "first_name": "Tomer",
-            "last_name": "Weller",
-            "email_address": "tomer@stellar.org"
-          },
-          "receivingClient": {
-            "first_name": "Lydia",
-            "last_name": "Wagner",
-            "email_address": "lydia@stellar.org"
-          },
-          "toBeDeleted": {
-            "first_name": "Jane",
-            "last_name": "Doe",
-            "email_address": "jane@email.com"
-          }
-        },
-        "createCustomer": "toBeCreated",
-        "deleteCustomer": "toBeDeleted",
-        "sameAccountDifferentMemos": ["sendingClient", "receivingClient"]
-      }}></Json>
-      <ul>
-        <li><strong>customers</strong>: an object containing subobjects for each customer that will be registered with the anchor. The key-value pairs within each subobject must be the <TextLink href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md">SEP-9</TextLink> attributes the anchor requires. Currently four customers are required.</li>
-        <li><strong>createCustomer</strong>: a string matching one of the keys within the customers object.</li>
-        <li><strong>deleteCustomer</strong>: a string matching one of the keys within the customers object.</li>
-        <li><strong>sameAccountDifferentMemos</strong>: an array with two strings, each of which must be keys in the customers object. Only required if SEP-31 configuration is not present.</li>
-      </ul>
       <p>
-        Each customers key assigned to the other attributes must be unique.
+        If your anchor requires binary data such as images or PDFs to properly
+        KYC customers, select the 'Upload Customer Files' button after uploading
+        the configuration file.
       </p>
+      <Json
+        src={{
+          customers: {
+            toBeCreated: {
+              first_name: "John",
+              last_name: "Doe",
+              email_address: "joe@email.com",
+              bank_number: "123",
+              bank_account_number: "123",
+            },
+            sendingClient: {
+              first_name: "Tomer",
+              last_name: "Weller",
+              email_address: "tomer@stellar.org",
+            },
+            receivingClient: {
+              first_name: "Lydia",
+              last_name: "Wagner",
+              email_address: "lydia@stellar.org",
+            },
+            toBeDeleted: {
+              first_name: "Jane",
+              last_name: "Doe",
+              email_address: "jane@email.com",
+            },
+          },
+          createCustomer: "toBeCreated",
+          deleteCustomer: "toBeDeleted",
+          sameAccountDifferentMemos: ["sendingClient", "receivingClient"],
+        }}
+      ></Json>
+      <ul>
+        <li>
+          <strong>customers</strong>: an object containing subobjects for each
+          customer that will be registered with the anchor. The key-value pairs
+          within each subobject must be the{" "}
+          <TextLink href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md">
+            SEP-9
+          </TextLink>{" "}
+          attributes the anchor requires. Currently four customers are required.
+        </li>
+        <li>
+          <strong>createCustomer</strong>: a string matching one of the keys
+          within the customers object.
+        </li>
+        <li>
+          <strong>deleteCustomer</strong>: a string matching one of the keys
+          within the customers object.
+        </li>
+        <li>
+          <strong>sameAccountDifferentMemos</strong>: an array with two strings,
+          each of which must be keys in the customers object. Only required if
+          SEP-31 configuration is not present.
+        </li>
+      </ul>
+      <p>Each customers key assigned to the other attributes must be unique.</p>
 
       <Heading4>SEP-31</Heading4>
       <p>
-        SEP-31 configuration objects are used for specifying a variety of data items outlined below.
+        SEP-31 configuration objects are used for specifying a variety of data
+        items outlined below.
       </p>
-      <Json src={{
-        "sendingAnchorClientSecret": "SB7E7M6VLBXXIEDJ4RXP7E4SS4CFDMFMIMWERJVY3MSRGNN5ROANA5OJ",
-        "sendingClientName": "sendingClient",
-        "receivingClientName": "receivingClient",
-        "transactionFields": {}
-      }}></Json>
+      <Json
+        src={{
+          sendingAnchorClientSecret:
+            "SB7E7M6VLBXXIEDJ4RXP7E4SS4CFDMFMIMWERJVY3MSRGNN5ROANA5OJ",
+          sendingClientName: "sendingClient",
+          receivingClientName: "receivingClient",
+          transactionFields: {},
+        }}
+      ></Json>
       <ul>
-        <li><strong>sendingAnchorClientSecret</strong>: the secret key for the Stellar keypair that should be used when authenticating with the receiving anchor via SEP-10</li>
-        <li><strong>sendingClientName</strong>: the key of the “customers” subobject that should be registered via SEP-12 as the sending client.</li>
-        <li><strong>receivingClientName</strong>: the key of the “customers” subobject that should be registered via SEP-12 as the receiving client.</li>
-        <li><strong>transactionFields</strong>: the <TextLink href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md#post-transactions">fields</TextLink> object that should be used in POST /transactions requests.</li>
+        <li>
+          <strong>sendingAnchorClientSecret</strong>: the secret key for the
+          Stellar keypair that should be used when authenticating with the
+          receiving anchor via SEP-10
+        </li>
+        <li>
+          <strong>sendingClientName</strong>: the key of the “customers”
+          subobject that should be registered via SEP-12 as the sending client.
+        </li>
+        <li>
+          <strong>receivingClientName</strong>: the key of the “customers”
+          subobject that should be registered via SEP-12 as the receiving
+          client.
+        </li>
+        <li>
+          <strong>transactionFields</strong>: the{" "}
+          <TextLink href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md#post-transactions">
+            fields
+          </TextLink>{" "}
+          object that should be used in POST /transactions requests.
+        </li>
       </ul>
       <p>
-        Note that there must be a subobject within SEP-12’s <strong>customers</strong> configuration object for the <strong>sendingClientName</strong> and <strong>receivingClientName</strong> properties.
+        Note that there must be a subobject within SEP-12’s{" "}
+        <strong>customers</strong> configuration object for the{" "}
+        <strong>sendingClientName</strong> and{" "}
+        <strong>receivingClientName</strong> properties.
       </p>
     </Modal.Body>
   </>

--- a/ui/src/components/ImageUploadModalContent/index.tsx
+++ b/ui/src/components/ImageUploadModalContent/index.tsx
@@ -4,109 +4,136 @@ import { Modal, Heading4, Select, Input, Button } from "@stellar/design-system";
 import { CustomerImageConfig } from "types/config";
 
 interface ImageModalProps {
-	imageConfig: Record<string, CustomerImageConfig>
-	setImageConfig: (ic: Record<string, CustomerImageConfig>) => void;
-	sep12Config: any;
+  imageConfig: Record<string, CustomerImageConfig>;
+  setImageConfig: (ic: Record<string, CustomerImageConfig>) => void;
+  sep12Config: any;
 }
 
 interface ImageFormData {
-	customerKey: string;
-	imageType: string;
-	fileName: string;
-	image: Buffer;
-};
+  customerKey: string;
+  imageType: string;
+  fileName: string;
+  image: Buffer;
+}
 
 interface ImageFormProps {
-	customerNames: string[];
-	formData?: ImageFormData;
-};
+  customerNames: string[];
+  formData?: ImageFormData;
+}
 
 const ImageUploadForm: React.FC<ImageFormProps> = (props) => {
-	const [imageFormData, setImageFormData] = useState(props.formData || {} as ImageFormData);
+  const [imageFormData, setImageFormData] = useState(
+    props.formData || ({} as ImageFormData),
+  );
 
-	const handleFileChange = async (files: FileList | null) => {
-		if (!files?.length) 
-			return;
-		const buf = Buffer.from(await files[0].arrayBuffer());
-		setImageFormData({ ...imageFormData, image: buf, fileName: files[0].name });
-	};
+  const handleFileChange = async (files: FileList | null) => {
+    if (!files?.length) return;
+    const buf = Buffer.from(await files[0].arrayBuffer());
+    setImageFormData({ ...imageFormData, image: buf, fileName: files[0].name });
+  };
 
-	return (
-		<>
-			<Select
-	     	id="customerKey"
-	     	label="Customer Key"
-	      onChange={(e) => setImageFormData({ ...imageFormData, customerKey: e.target.value })}
-	    >
-	      {props.customerNames.map((ck) => (
-	        <option key={ck} value={ck}>{ck}</option>
-	      ))}
-	    </Select>	
-	    <Select
-	    	id="imageType"
-	    	label="Image Type"
-	    	onChange={(e) => setImageFormData({ ...imageFormData, imageType: e.target.value })}
-	   	>
-	   		<option key="photo_id_front" value="PhotoIdFront">Photo ID (front)</option>
-	   		<option key="photo_id_back" value="PhotoIdBack">Photo ID (back)</option>
-	   		<option key="notary_approval_of_photo_id" value="NotaryApprovalOfPhotoId">Notary Approval of Photo ID</option>
-	   		<option key="photo_proof_residence" value="PhotoProofResidence">Photo Proof of Residence</option>
-	    </Select>
-	    {!imageFormData.fileName && (
-	    	<Input
-		    	id="imageFile"
-		    	type="file"
-		    	label="Upload Image"
-		    	onChange={(e) => handleFileChange(e.target.files)}
-		    />
-	    )}
-	    {imageFormData.fileName && (
-	    	<p>{imageFormData.fileName}</p>
-	    )}
-	  </>
-	);
+  return (
+    <>
+      <Select
+        id="customerKey"
+        label="Customer Key"
+        onChange={(e) =>
+          setImageFormData({ ...imageFormData, customerKey: e.target.value })
+        }
+      >
+        {props.customerNames.map((ck) => (
+          <option key={ck} value={ck}>
+            {ck}
+          </option>
+        ))}
+      </Select>
+      <Select
+        id="imageType"
+        label="Image Type"
+        onChange={(e) =>
+          setImageFormData({ ...imageFormData, imageType: e.target.value })
+        }
+      >
+        <option key="photo_id_front" value="PhotoIdFront">
+          Photo ID (front)
+        </option>
+        <option key="photo_id_back" value="PhotoIdBack">
+          Photo ID (back)
+        </option>
+        <option
+          key="notary_approval_of_photo_id"
+          value="NotaryApprovalOfPhotoId"
+        >
+          Notary Approval of Photo ID
+        </option>
+        <option key="photo_proof_residence" value="PhotoProofResidence">
+          Photo Proof of Residence
+        </option>
+      </Select>
+      {!imageFormData.fileName && (
+        <Input
+          id="imageFile"
+          type="file"
+          label="Upload Image"
+          onChange={(e) => handleFileChange(e.target.files)}
+        />
+      )}
+      {imageFormData.fileName && <p>{imageFormData.fileName}</p>}
+    </>
+  );
 };
 
-export const ImageUploadModalContent: React.FC<ImageModalProps> = ({ imageConfig, sep12Config }) => {
-	const addImageUploadForm = () => {
+export const ImageUploadModalContent: React.FC<ImageModalProps> = ({
+  imageConfig,
+  sep12Config,
+}) => {
+  const addImageUploadForm = () => {};
 
-	};
-
-	return (
-		<>
-			<Modal.Heading>Upload Customer Images</Modal.Heading>
-			<Modal.Body>
-				<p>
-					Anchors often require images of customer documents as a part of the KYC process. 
-					For example, an anchor may require a user's photo ID before allowing a withdrawal of funds over a certain limit.
-					If your anchor does not require any images of customer records, you can close this window and continue testing.
-				</p>
-				<p>
-					To associate an image with a customer, select the customer from the dropdown menu below, specify the type of document you would like to upload, and upload the file.
-				</p>
-				<Heading4>Customer Images</Heading4>
-				{Object.entries(imageConfig).map(([customerKey, customerImageConfig]) => {
-					return (
-						<>
-							{Object.entries(customerImageConfig).map(([imageType, imageNameAndBuffer]) => {
-								return (
-									<ImageUploadForm 
-										customerNames={Object.keys(sep12Config.customers)}
-										formData={{
-											customerKey: customerKey,
-											imageType: imageType,
-											fileName: imageNameAndBuffer[0],
-											image: imageNameAndBuffer[1]
-										}}
-									/>
-								);
-							})}
-						</>
-					);
-				})}
-				<ImageUploadForm customerNames={Object.keys(sep12Config.customers)} />
-				<Button id="addImageUploadFormButton" onClick={addImageUploadForm}>Add Image</Button>
-			</Modal.Body>
-		</>
-	);
+  return (
+    <>
+      <Modal.Heading>Upload Customer Images</Modal.Heading>
+      <Modal.Body>
+        <p>
+          Anchors often require images of customer documents as a part of the
+          KYC process. For example, an anchor may require a user's photo ID
+          before allowing a withdrawal of funds over a certain limit. If your
+          anchor does not require any images of customer records, you can close
+          this window and continue testing.
+        </p>
+        <p>
+          To associate an image with a customer, select the customer from the
+          dropdown menu below, specify the type of document you would like to
+          upload, and upload the file.
+        </p>
+        <Heading4>Customer Images</Heading4>
+        {Object.entries(imageConfig).map(
+          ([customerKey, customerImageConfig]) => {
+            return (
+              <>
+                {Object.entries(customerImageConfig).map(
+                  ([imageType, imageNameAndBuffer]) => {
+                    return (
+                      <ImageUploadForm
+                        customerNames={Object.keys(sep12Config.customers)}
+                        formData={{
+                          customerKey: customerKey,
+                          imageType: imageType,
+                          fileName: imageNameAndBuffer[0],
+                          image: imageNameAndBuffer[1],
+                        }}
+                      />
+                    );
+                  },
+                )}
+              </>
+            );
+          },
+        )}
+        <ImageUploadForm customerNames={Object.keys(sep12Config.customers)} />
+        <Button id="addImageUploadFormButton" onClick={addImageUploadForm}>
+          Add Image
+        </Button>
+      </Modal.Body>
+    </>
+  );
 };

--- a/ui/src/components/ImageUploadModalContent/index.tsx
+++ b/ui/src/components/ImageUploadModalContent/index.tsx
@@ -96,6 +96,13 @@ const ImageUploadForm: React.FC<ImageFormProps> = ({
     setImageData(imageDataCopy);
   };
 
+  useEffect(() => {
+    const updates: ImageFormData = {};
+    if (!imageData[index].customerKey) updates.customerKey = customerNames[0];
+    if (!imageData[index].imageType) updates.imageType = "photo_id_front";
+    if (Object.keys(updates).length) updateImageData(updates);
+  }, []);
+
   return (
     <>
       <Select
@@ -201,7 +208,7 @@ export const ImageUploadModalContent: React.FC<ImageModalProps> = ({
             <ImageFormContainer key={"form-container-" + i}>
               <HeadingWrapper>
                 <Eyebrow style={eyebrowStyle}>{i + 1}.</Eyebrow>
-                {i != 0 && (
+                {i !== 0 && (
                   <Button
                     variant={Button.variant.secondary}
                     style={xFormButtonStyle}

--- a/ui/src/components/ImageUploadModalContent/index.tsx
+++ b/ui/src/components/ImageUploadModalContent/index.tsx
@@ -142,7 +142,7 @@ const ImageUploadForm: React.FC<ImageFormProps> = ({
       )}
       {imageData[index].fileName && (
         <>
-          <label>UPLOADED IMAGE</label>
+          <label>UPLOAD IMAGE</label>
           <UploadedFileWrapper>
             {imageData[index].fileName}
             <Button
@@ -201,13 +201,15 @@ export const ImageUploadModalContent: React.FC<ImageModalProps> = ({
             <ImageFormContainer key={"form-container-" + i}>
               <HeadingWrapper>
                 <Eyebrow style={eyebrowStyle}>{i + 1}.</Eyebrow>
-                <Button
-                  variant={Button.variant.secondary}
-                  style={xFormButtonStyle}
-                  onClick={() => removeForm(i)}
-                >
-                  Remove Form
-                </Button>
+                {i != 0 && (
+                  <Button
+                    variant={Button.variant.secondary}
+                    style={xFormButtonStyle}
+                    onClick={() => removeForm(i)}
+                  >
+                    Remove Form
+                  </Button>
+                )}
               </HeadingWrapper>
               <ImageUploadForm
                 customerNames={Object.keys(sep12Config.customers)}
@@ -218,8 +220,12 @@ export const ImageUploadModalContent: React.FC<ImageModalProps> = ({
             </ImageFormContainer>
           );
         })}
-        <Button id="addImageUploadFormButton" onClick={addImageUploadForm}>
-          Add Image
+        <Button
+          id="addImageUploadFormButton"
+          onClick={addImageUploadForm}
+          disabled={!imageData.every((i) => Boolean(i.fileName))}
+        >
+          Add Form
         </Button>
       </Modal.Body>
     </>

--- a/ui/src/components/ImageUploadModalContent/index.tsx
+++ b/ui/src/components/ImageUploadModalContent/index.tsx
@@ -85,7 +85,11 @@ const ImageUploadForm: React.FC<ImageFormProps> = ({
   const handleFileChange = async (files: FileList | null) => {
     if (!files?.length) return;
     const buf = Buffer.from(await files[0].arrayBuffer());
-    updateImageData({ image: buf, fileName: files[0].name });
+    updateImageData({
+      image: buf,
+      fileName: files[0].name,
+      fileType: files[0].type,
+    });
   };
 
   const removeFile = (_index: number) => {
@@ -94,6 +98,7 @@ const ImageUploadForm: React.FC<ImageFormProps> = ({
       ...imageDataCopy[index],
       image: undefined,
       fileName: undefined,
+      fileType: undefined,
     };
     imageDataCopy[index] = formDataCopy;
     setImageData(imageDataCopy);
@@ -122,7 +127,7 @@ const ImageUploadForm: React.FC<ImageFormProps> = ({
       </Select>
       <Select
         id="imageType"
-        label="Image Type"
+        label="Document Type"
         onChange={(e) => updateImageData({ imageType: e.target.value })}
         value={imageData[index].imageType}
       >
@@ -146,13 +151,14 @@ const ImageUploadForm: React.FC<ImageFormProps> = ({
         <Input
           id="imageFile"
           type="file"
-          label="Upload Image"
+          label="Upload File"
           onChange={(e) => handleFileChange(e.target.files)}
+          accept="image/*,.pdf"
         />
       )}
       {imageData[index].fileName && (
         <>
-          <label>UPLOAD IMAGE</label>
+          <label>UPLOAD FILE</label>
           <UploadedFileWrapper>
             {imageData[index].fileName}
             <Button
@@ -191,21 +197,21 @@ export const ImageUploadModalContent: React.FC<ImageModalProps> = ({
 
   return (
     <>
-      <Modal.Heading>Upload Customer Images</Modal.Heading>
+      <Modal.Heading>Upload Customer Files</Modal.Heading>
       <Modal.Body>
         <p>
-          Anchors often require images of customer documents as a part of the
-          KYC process. For example, an anchor may require a user's photo ID
-          before allowing a withdrawal of funds over a certain limit. If your
-          anchor does not require any images of customer records, you can close
-          this window and continue testing.
+          Anchors often require files, usually images, of customer documents as
+          a part of the KYC process. For example, an anchor may require a user's
+          photo ID before allowing a withdrawal of funds over a certain limit.
+          If your anchor does not require any images of customer records, you
+          can close this window and continue testing.
         </p>
         <p>
-          To associate an image with a customer, select the customer from the
+          To associate a file with a customer, select the customer from the
           dropdown menu below, specify the type of document you would like to
           upload, and upload the file.
         </p>
-        <Heading4>Customer Images</Heading4>
+        <Heading4>Customer Files</Heading4>
         {imageData.map((_, i) => {
           return (
             <ImageFormContainer key={"form-container-" + i}>

--- a/ui/src/components/ImageUploadModalContent/index.tsx
+++ b/ui/src/components/ImageUploadModalContent/index.tsx
@@ -15,6 +15,7 @@ interface ImageModalProps {
   imageData: ImageFormData[];
   setImageData: (data: ImageFormData[]) => void;
   sep12Config: any;
+  setIsImageUploadModalVisible: (isVisible: boolean) => void;
 }
 
 interface ImageFormProps {
@@ -48,6 +49,19 @@ const xFileButtonStyle = {
 
 const eyebrowStyle = {
   fontSize: "1rem",
+};
+
+const BottomButtonsWrapper = styled.div`
+  display: flex;
+  position: relative;
+`;
+
+const DoneButtonStyle = {
+  marginLeft: "1rem",
+};
+
+const AddFormButtonStyle = {
+  marginLeft: "auto",
 };
 
 const UploadedFileWrapper = styled.div`
@@ -179,6 +193,7 @@ export const ImageUploadModalContent: React.FC<ImageModalProps> = ({
   imageData,
   setImageData,
   sep12Config,
+  setIsImageUploadModalVisible,
 }) => {
   const addImageUploadForm = useCallback(() => {
     setImageData([...imageData, {}]);
@@ -236,13 +251,23 @@ export const ImageUploadModalContent: React.FC<ImageModalProps> = ({
             </ImageFormContainer>
           );
         })}
-        <Button
-          id="addImageUploadFormButton"
-          onClick={addImageUploadForm}
-          disabled={!imageData.every((i) => Boolean(i.fileName))}
-        >
-          Add Form
-        </Button>
+        <BottomButtonsWrapper>
+          <Button
+            id="addImageUploadFormButton"
+            onClick={addImageUploadForm}
+            disabled={!imageData.every((i) => Boolean(i.fileName))}
+            style={AddFormButtonStyle}
+          >
+            + New Form
+          </Button>
+          <Button
+            id="doneUploadFormButton"
+            onClick={() => setIsImageUploadModalVisible(false)}
+            style={DoneButtonStyle}
+          >
+            Done
+          </Button>
+        </BottomButtonsWrapper>
       </Modal.Body>
     </>
   );

--- a/ui/src/components/ImageUploadModalContent/index.tsx
+++ b/ui/src/components/ImageUploadModalContent/index.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { useState } from "react";
+import { Modal, Heading4, Select, Input, Button } from "@stellar/design-system";
+import { CustomerImageConfig } from "types/config";
+
+interface ImageModalProps {
+	imageConfig: Record<string, CustomerImageConfig>
+	setImageConfig: (ic: Record<string, CustomerImageConfig>) => void;
+	sep12Config: any;
+}
+
+interface ImageFormData {
+	customerKey: string;
+	imageType: string;
+	fileName: string;
+	image: Buffer;
+};
+
+interface ImageFormProps {
+	customerNames: string[];
+	formData?: ImageFormData;
+};
+
+const ImageUploadForm: React.FC<ImageFormProps> = (props) => {
+	const [imageFormData, setImageFormData] = useState(props.formData || {} as ImageFormData);
+
+	const handleFileChange = async (files: FileList | null) => {
+		if (!files?.length) 
+			return;
+		const buf = Buffer.from(await files[0].arrayBuffer());
+		setImageFormData({ ...imageFormData, image: buf, fileName: files[0].name });
+	};
+
+	return (
+		<>
+			<Select
+	     	id="customerKey"
+	     	label="Customer Key"
+	      onChange={(e) => setImageFormData({ ...imageFormData, customerKey: e.target.value })}
+	    >
+	      {props.customerNames.map((ck) => (
+	        <option key={ck} value={ck}>{ck}</option>
+	      ))}
+	    </Select>	
+	    <Select
+	    	id="imageType"
+	    	label="Image Type"
+	    	onChange={(e) => setImageFormData({ ...imageFormData, imageType: e.target.value })}
+	   	>
+	   		<option key="photo_id_front" value="PhotoIdFront">Photo ID (front)</option>
+	   		<option key="photo_id_back" value="PhotoIdBack">Photo ID (back)</option>
+	   		<option key="notary_approval_of_photo_id" value="NotaryApprovalOfPhotoId">Notary Approval of Photo ID</option>
+	   		<option key="photo_proof_residence" value="PhotoProofResidence">Photo Proof of Residence</option>
+	    </Select>
+	    {!imageFormData.fileName && (
+	    	<Input
+		    	id="imageFile"
+		    	type="file"
+		    	label="Upload Image"
+		    	onChange={(e) => handleFileChange(e.target.files)}
+		    />
+	    )}
+	    {imageFormData.fileName && (
+	    	<p>{imageFormData.fileName}</p>
+	    )}
+	  </>
+	);
+};
+
+export const ImageUploadModalContent: React.FC<ImageModalProps> = ({ imageConfig, sep12Config }) => {
+	const addImageUploadForm = () => {
+
+	};
+
+	return (
+		<>
+			<Modal.Heading>Upload Customer Images</Modal.Heading>
+			<Modal.Body>
+				<p>
+					Anchors often require images of customer documents as a part of the KYC process. 
+					For example, an anchor may require a user's photo ID before allowing a withdrawal of funds over a certain limit.
+					If your anchor does not require any images of customer records, you can close this window and continue testing.
+				</p>
+				<p>
+					To associate an image with a customer, select the customer from the dropdown menu below, specify the type of document you would like to upload, and upload the file.
+				</p>
+				<Heading4>Customer Images</Heading4>
+				{Object.entries(imageConfig).map(([customerKey, customerImageConfig]) => {
+					return (
+						<>
+							{Object.entries(customerImageConfig).map(([imageType, imageNameAndBuffer]) => {
+								return (
+									<ImageUploadForm 
+										customerNames={Object.keys(sep12Config.customers)}
+										formData={{
+											customerKey: customerKey,
+											imageType: imageType,
+											fileName: imageNameAndBuffer[0],
+											image: imageNameAndBuffer[1]
+										}}
+									/>
+								);
+							})}
+						</>
+					);
+				})}
+				<ImageUploadForm customerNames={Object.keys(sep12Config.customers)} />
+				<Button id="addImageUploadFormButton" onClick={addImageUploadForm}>Add Image</Button>
+			</Modal.Body>
+		</>
+	);
+};

--- a/ui/src/components/ImageUploadModalContent/index.tsx
+++ b/ui/src/components/ImageUploadModalContent/index.tsx
@@ -72,12 +72,15 @@ const ImageUploadForm: React.FC<ImageFormProps> = ({
   setImageData,
   index,
 }) => {
-  const updateImageData = (updates: object) => {
-    const imageDataCopy = [...imageData];
-    const formDataCopy = { ...imageDataCopy[index], ...updates };
-    imageDataCopy[index] = formDataCopy;
-    setImageData(imageDataCopy);
-  };
+  const updateImageData = useCallback(
+    (updates: object) => {
+      const imageDataCopy = [...imageData];
+      const formDataCopy = { ...imageDataCopy[index], ...updates };
+      imageDataCopy[index] = formDataCopy;
+      setImageData(imageDataCopy);
+    },
+    [imageData, setImageData, index],
+  );
 
   const handleFileChange = async (files: FileList | null) => {
     if (!files?.length) return;
@@ -101,7 +104,7 @@ const ImageUploadForm: React.FC<ImageFormProps> = ({
     if (!imageData[index].customerKey) updates.customerKey = customerNames[0];
     if (!imageData[index].imageType) updates.imageType = "photo_id_front";
     if (Object.keys(updates).length) updateImageData(updates);
-  }, []);
+  }, [customerNames, imageData, index, updateImageData]);
 
   return (
     <>

--- a/ui/src/components/TestRunner/index.tsx
+++ b/ui/src/components/TestRunner/index.tsx
@@ -474,7 +474,7 @@ export const TestRunner = () => {
                   !Boolean(formData.sepConfig && formData.sepConfig["12"])
                 }
               >
-                Upload Files
+                Upload Customer Files
               </Button>
               {customerImageData.some((cid) => Boolean(cid.fileName)) && (
                 <p style={numUploadedFilesStyle}>

--- a/ui/src/components/TestRunner/index.tsx
+++ b/ui/src/components/TestRunner/index.tsx
@@ -219,6 +219,7 @@ export const TestRunner = () => {
       customerCopy[ifd.imageType] = {
         data: ifd.image,
         contentType: ifd.fileType,
+        fileName: ifd.fileName,
       };
       formDataCopy.sepConfig["12"].customers[ifd.customerKey] = customerCopy;
     }

--- a/ui/src/components/TestRunner/index.tsx
+++ b/ui/src/components/TestRunner/index.tsx
@@ -21,7 +21,7 @@ import {
   RunState,
   TestCase,
 } from "types/testCases";
-import { CustomerImageConfig } from "types/config";
+import { ImageFormData } from "types/config";
 import { ImageUploadModalContent } from "../ImageUploadModalContent";
 import { HomeDomainField } from "../TestRunnerFields/HomeDomainField";
 import { TestCases } from "../TestCases";
@@ -71,16 +71,17 @@ export const TestRunner = () => {
   );
   const [supportedAssets, setSupportedAssets] = useState([] as string[]);
   const [supportedSeps, setSupportedSeps] = useState([] as number[]);
-  const [customerImageConfig, setCustomerImageConfig] = useState(
-    {} as Record<string, CustomerImageConfig>
+  const [customerImageData, setCustomerImageData] = useState(
+    [] as ImageFormData[],
   );
-  const [isImageUploadModalVisible, setIsImageUploadModalVisible] = useState(false);
+  const [isImageUploadModalVisible, setIsImageUploadModalVisible] =
+    useState(false);
 
   const resetAllState = () => {
     setRunState(RunState.noTests);
     setServerFailure("");
     setIsConfigNeeded(false);
-    setCustomerImageConfig({});
+    setCustomerImageData([]);
     setSupportedAssets([]);
     setSupportedSeps([]);
     setToml(undefined);
@@ -400,9 +401,14 @@ export const TestRunner = () => {
               </Modal>
             </FieldWrapper>
             <FieldWrapper>
-              <Button 
-                onClick={(e) => { e.preventDefault(); setIsImageUploadModalVisible(true); } }
-                disabled={!Boolean(formData.sepConfig && formData.sepConfig["12"])}
+              <Button
+                onClick={(e) => {
+                  e.preventDefault();
+                  setIsImageUploadModalVisible(true);
+                }}
+                disabled={
+                  !Boolean(formData.sepConfig && formData.sepConfig["12"])
+                }
               >
                 Upload Images
               </Button>
@@ -410,10 +416,12 @@ export const TestRunner = () => {
                 visible={isImageUploadModalVisible}
                 onClose={() => setIsImageUploadModalVisible(false)}
               >
-                <ImageUploadModalContent 
-                  imageConfig={customerImageConfig}
-                  setImageConfig={setCustomerImageConfig}
-                  sep12Config={formData.sepConfig ? formData.sepConfig["12"] : undefined}
+                <ImageUploadModalContent
+                  imageData={customerImageData}
+                  setImageData={setCustomerImageData}
+                  sep12Config={
+                    formData.sepConfig ? formData.sepConfig["12"] : undefined
+                  }
                 ></ImageUploadModalContent>
               </Modal>
             </FieldWrapper>

--- a/ui/src/components/TestRunner/index.tsx
+++ b/ui/src/components/TestRunner/index.tsx
@@ -216,7 +216,10 @@ export const TestRunner = () => {
       const customerCopy = {
         ...formDataCopy.sepConfig["12"].customers[ifd.customerKey],
       };
-      customerCopy[ifd.imageType] = ifd.image;
+      customerCopy[ifd.imageType] = {
+        data: ifd.image,
+        contentType: ifd.fileType,
+      };
       formDataCopy.sepConfig["12"].customers[ifd.customerKey] = customerCopy;
     }
     return formDataCopy;
@@ -445,6 +448,7 @@ export const TestRunner = () => {
                 label="Upload Config"
                 onChange={(e) => handleFileChange(e.target.files)}
                 type="file"
+                accept="application/json"
               />
               <ModalInfoButton onClick={() => setIsModalVisible(true)} />
 
@@ -465,7 +469,7 @@ export const TestRunner = () => {
                   !Boolean(formData.sepConfig && formData.sepConfig["12"])
                 }
               >
-                Upload Images
+                Upload Files
               </Button>
               <Modal
                 visible={isImageUploadModalVisible}

--- a/ui/src/components/TestRunner/index.tsx
+++ b/ui/src/components/TestRunner/index.tsx
@@ -319,7 +319,14 @@ export const TestRunner = () => {
   };
 
   const handleFileChange = (files: FileList | null) => {
-    if (!files?.length) return;
+    if (!files?.length) {
+      setServerFailure("");
+      setFormData({
+        ...formData,
+        sepConfig: undefined,
+      });
+      return;
+    }
     const fileReader = new FileReader();
     fileReader.readAsText(files[0], "UTF-8");
     fileReader.onload = (e) => {

--- a/ui/src/components/TestRunner/index.tsx
+++ b/ui/src/components/TestRunner/index.tsx
@@ -50,6 +50,10 @@ const ResetButtonWrapper = styled.div`
   margin-left: 1rem;
 `;
 
+const numUploadedFilesStyle = {
+  paddingLeft: "1rem",
+};
+
 const defaultFormData = {
   homeDomain: "",
   seps: [],
@@ -472,6 +476,22 @@ export const TestRunner = () => {
               >
                 Upload Files
               </Button>
+              {customerImageData.some((cid) => Boolean(cid.fileName)) && (
+                <p style={numUploadedFilesStyle}>
+                  {customerImageData.reduce(
+                    (prev, cur) => prev + (cur.fileName ? 1 : 0),
+                    0,
+                  )}{" "}
+                  file
+                  {customerImageData.reduce(
+                    (prev, cur) => prev + (cur.fileName ? 1 : 0),
+                    0,
+                  ) > 1
+                    ? "s"
+                    : ""}{" "}
+                  uploaded
+                </p>
+              )}
               <Modal
                 visible={isImageUploadModalVisible}
                 onClose={() => setIsImageUploadModalVisible(false)}
@@ -482,6 +502,7 @@ export const TestRunner = () => {
                   sep12Config={
                     formData.sepConfig ? formData.sepConfig["12"] : undefined
                   }
+                  setIsImageUploadModalVisible={setIsImageUploadModalVisible}
                 ></ImageUploadModalContent>
               </Modal>
             </FieldWrapper>

--- a/ui/src/components/TestRunnerFields/HomeDomainField.tsx
+++ b/ui/src/components/TestRunnerFields/HomeDomainField.tsx
@@ -67,7 +67,9 @@ export const HomeDomainField = ({
     }
     let tomlObj;
     try {
-      tomlObj = await StellarTomlResolver.resolve(homeDomainHost);
+      tomlObj = await StellarTomlResolver.resolve(homeDomainHost, {
+        allowHttp: homeDomain.startsWith("http:"),
+      });
     } catch {
       resetAllState();
       setServerFailure("Unable to fetch SEP-1 stellar.toml file");
@@ -121,11 +123,7 @@ export const HomeDomainField = ({
         </TooltipInfoButton>
       </FieldWrapper>
       <FieldWrapper>
-        <Button
-          onClick={(e) => fetchDomain(e)}
-        >
-          Fetch Stellar Info File
-        </Button>
+        <Button onClick={(e) => fetchDomain(e)}>Fetch Stellar Info File</Button>
       </FieldWrapper>
     </>
   );

--- a/ui/src/components/TestRunnerFields/HomeDomainField.tsx
+++ b/ui/src/components/TestRunnerFields/HomeDomainField.tsx
@@ -122,7 +122,6 @@ export const HomeDomainField = ({
       </FieldWrapper>
       <FieldWrapper>
         <Button
-          variant={Button.variant.secondary}
           onClick={(e) => fetchDomain(e)}
         >
           Fetch Stellar Info File

--- a/ui/src/types/config.ts
+++ b/ui/src/types/config.ts
@@ -1,6 +1,6 @@
-export interface CustomerImageConfig {
-  PhotoIdFront?: [string, Buffer];
-  PhotoIdBack?: [string, Buffer];
-  NotaryApprovalOfPhotoId?: [string, Buffer];
-  PhotoProofResidence?: [string, Buffer];
+export interface ImageFormData {
+  customerKey?: string;
+  imageType?: string;
+  fileName?: string;
+  image?: Buffer;
 }

--- a/ui/src/types/config.ts
+++ b/ui/src/types/config.ts
@@ -1,6 +1,7 @@
 export interface ImageFormData {
   customerKey?: string;
   imageType?: string;
+  fileType?: string;
   fileName?: string;
   image?: Buffer;
 }

--- a/ui/src/types/config.ts
+++ b/ui/src/types/config.ts
@@ -1,0 +1,6 @@
+export interface CustomerImageConfig {
+  PhotoIdFront?: [string, Buffer];
+  PhotoIdBack?: [string, Buffer];
+  NotaryApprovalOfPhotoId?: [string, Buffer];
+  PhotoProofResidence?: [string, Buffer];
+}


### PR DESCRIPTION
## Changes

### UI
- Uses the primary button variant for the 'Fetch Stellar Info File' button to match others
- Disables 'Run Tests' button if selected SEP requires a configuration file and one has not yet been uploaded
- Adds a 'Upload Customer Files' button
- Selecting the button will bring up a 'Upload Customer Files' modal presenting an explanation and form for uploading files for customers. Users can add new forms and upload N files for any customer included in their configuration file.
- Selecting 'Run Tests' sends uploaded files to the server in the expected format
- Included `.tsx` files in prettier's set of files, so thats why there are formatting changes

### Anchor Test Suite
- Updates the version to v0.2.0
    - TODO: If I'm OOO when this is merged, create a new tag and a new release of the test suite will be created
- Adjusts the expected sepConfig format for binary data types
- Adjusts the `makeSep12Request()` logic to make proper `multipart/form-data` requests.