### PR TITLE
SEP-38 Tests

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/cli.ts
+++ b/@stellar/anchor-tests/src/cli.ts
@@ -66,8 +66,8 @@ const command = yargs
     }
     if (argv.seps) {
       for (const sep of argv.seps) {
-        if (![1, 6, 10, 12, 24, 31].includes(sep))
-          throw "error: invalid --sep value provided. Choices: 1, 6, 10, 12, 24, 31.";
+        if (![1, 6, 10, 12, 24, 31, 38].includes(sep))
+          throw "error: invalid --sep value provided. Choices: 1, 6, 10, 12, 24, 31, 38.";
       }
       if (
         (argv.seps.includes(6) ||

--- a/@stellar/anchor-tests/src/helpers/console.ts
+++ b/@stellar/anchor-tests/src/helpers/console.ts
@@ -76,15 +76,6 @@ async function printColoredTextTestRun(testRun: TestRun, verbose: boolean) {
       console.groupEnd(); // resource links group
     }
   }
-  if (verbose && testRun.result.failure && testRun.result.failure.links) {
-    console.log(c.bold("Relevant Links:\n"));
-    console.group(); // failure links group
-    for (const linkLabel in testRun.result.failure.links) {
-      console.log(`${linkLabel}: ${testRun.result.failure.links[linkLabel]}`);
-    }
-    console.groupEnd(); // failure links group
-    console.log();
-  }
   if (verbose && testRun.result.failure && testRun.result.networkCalls.length) {
     console.log(c.bold("Network Calls:\n"));
     for (const networkCall of testRun.result.networkCalls) {

--- a/@stellar/anchor-tests/src/helpers/test.ts
+++ b/@stellar/anchor-tests/src/helpers/test.ts
@@ -7,6 +7,7 @@ import { default as sep10Tests } from "../tests/sep10/tests";
 import { default as sep12Tests } from "../tests/sep12/tests";
 import { default as sep24Tests } from "../tests/sep24/tests";
 import { default as sep31Tests } from "../tests/sep31/tests";
+import { default as sep38Tests } from "../tests/sep38/tests";
 import { makeFailure } from "./failure";
 import { checkConfig } from "./config";
 
@@ -330,6 +331,9 @@ function getTopLevelTests(config: Config): Test[] {
   }
   if (config.seps.includes(31)) {
     tests = tests.concat(sep31Tests);
+  }
+  if (config.seps.includes(38)) {
+    tests = tests.concat(sep38Tests);
   }
   return filterBySearchStrings(tests, config.searchStrings as string[]);
 }

--- a/@stellar/anchor-tests/src/schemas/config.ts
+++ b/@stellar/anchor-tests/src/schemas/config.ts
@@ -106,7 +106,7 @@ export const configSchema = {
     seps: {
       type: "array",
       items: {
-        enum: [1, 6, 10, 12, 24, 31],
+        enum: [1, 6, 10, 12, 24, 31, 38],
       },
     },
     verbose: {

--- a/@stellar/anchor-tests/src/schemas/sep38.ts
+++ b/@stellar/anchor-tests/src/schemas/sep38.ts
@@ -1,0 +1,51 @@
+export const infoSchema = {
+  type: "object",
+  properties: {
+    assets: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          asset: {
+            type: "string",
+          },
+          country_codes: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+          sell_delivery_methods: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                },
+                description: {
+                  type: "string",
+                },
+              },
+            },
+          },
+          buy_delivery_methods: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                },
+                description: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
+        required: ["asset"],
+      },
+    },
+  },
+};

--- a/@stellar/anchor-tests/src/schemas/sep38.ts
+++ b/@stellar/anchor-tests/src/schemas/sep38.ts
@@ -49,3 +49,44 @@ export const infoSchema = {
     },
   },
 };
+
+export const pricesSchema = {
+  type: "object",
+  properties: {
+    buy_assets: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          asset: {
+            type: "string",
+          },
+          price: {
+            type: "string",
+          },
+          decimals: {
+            type: "integer",
+          },
+        },
+        required: ["asset", "price", "decimals"],
+      },
+    },
+  },
+  required: ["buy_assets"],
+};
+
+export const priceSchema = {
+  type: "object",
+  properties: {
+    price: {
+      type: "string",
+    },
+    sell_amount: {
+      type: "string",
+    },
+    buy_amount: {
+      type: "string",
+    },
+  },
+  required: ["price", "sell_amount", "buy_amount"],
+};

--- a/@stellar/anchor-tests/src/schemas/sep38.ts
+++ b/@stellar/anchor-tests/src/schemas/sep38.ts
@@ -72,6 +72,7 @@ export const pricesSchema = {
       },
     },
   },
+  additionalProperties: false,
   required: ["buy_assets"],
 };
 
@@ -88,5 +89,44 @@ export const priceSchema = {
       type: "string",
     },
   },
+  additionalProperties: false,
   required: ["price", "sell_amount", "buy_amount"],
+};
+
+export const quoteSchema = {
+  type: "object",
+  properties: {
+    id: {
+      type: "string",
+    },
+    expires_at: {
+      type: "string",
+      format: "date-time",
+    },
+    price: {
+      type: "string",
+    },
+    sell_asset: {
+      type: "string",
+    },
+    buy_asset: {
+      type: "string",
+    },
+    sell_amount: {
+      type: "string",
+    },
+    buy_amount: {
+      type: "string",
+    },
+  },
+  additionalProperties: false,
+  required: [
+    "id",
+    "expires_at",
+    "price",
+    "sell_asset",
+    "buy_asset",
+    "sell_amount",
+    "buy_amount",
+  ],
 };

--- a/@stellar/anchor-tests/src/tests/sep31/info.ts
+++ b/@stellar/anchor-tests/src/tests/sep31/info.ts
@@ -32,7 +32,7 @@ const hasValidInfoSchema: Test = {
       },
       links: {
         "Info Response":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#6-error",
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md#get-info",
       },
     },
     ...genericFailures,
@@ -51,9 +51,9 @@ const hasValidInfoSchema: Test = {
       result,
       "application/json",
     );
-    if (!this.context.provides.infoObj) return result;
+    if (!this.context.provides.sep31InfoObj) return result;
     const validationResult = validate(
-      this.context.provides.infoObj,
+      this.context.provides.sep31InfoObj,
       infoSchema,
     );
     if (validationResult.errors.length !== 0) {

--- a/@stellar/anchor-tests/src/tests/sep38/getQuote.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/getQuote.ts
@@ -1,0 +1,201 @@
+import { Request } from "node-fetch";
+import { validate } from "jsonschema";
+import { isDeepStrictEqual } from "util";
+
+import { Test, Result, Config, NetworkCall } from "../../types";
+import { hasQuoteServer } from "./toml";
+import { genericFailures, makeFailure } from "../../helpers/failure";
+import { makeRequest } from "../../helpers/request";
+import { quoteSchema } from "../../schemas/sep38";
+import { returnsValidJwt } from "../sep10/tests";
+import { canCreateQuote } from "./postQuote";
+
+export const requiresJwt: Test = {
+  sep: 38,
+  assertion: "requires SEP-10 authentication",
+  group: "GET /quote",
+  dependencies: [hasQuoteServer],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+      sep38QuoteResponseObj: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_ERROR_SCHEMA: {
+      name: "invalid error schema",
+      text(_args: any): string {
+        return "All error responses should contain a JSON body with an 'error' key-value pair";
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/quote/" +
+          this.context.expects.sep38QuoteResponseObj.id,
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const quoteResponse = await makeRequest(
+      networkCall,
+      403,
+      result,
+      "application/json",
+    );
+    if (!quoteResponse) return result;
+    if (!quoteResponse.error) {
+      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
+      return result;
+    }
+    return result;
+  },
+};
+
+export const canFetchQuote: Test = {
+  sep: 38,
+  assertion: "can fetch existing quote",
+  group: "GET /quote",
+  dependencies: [returnsValidJwt, canCreateQuote],
+  context: {
+    expects: {
+      token: undefined,
+      quoteServerUrl: undefined,
+      sep38QuoteResponseObj: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_SCHEMA: {
+      name: "invalid GET /quote schema",
+      text(args: any): string {
+        return (
+          "The response body from GET /quote does not match the schema defined by the protocol. " +
+          "Errors:\n\n" +
+          `${args.errors}`
+        );
+      },
+      links: {
+        "GET /prices Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-4",
+      },
+    },
+    QUOTE_BODY_DOESNT_MATCH: {
+      name: "quote response bodies don't match",
+      text(args: any): string {
+        return (
+          "The response body returned from POST /quote does not match the response body returned from " +
+          `GET /quote:\n\nExpected:\n${JSON.stringify(
+            args.expectedBody,
+            null,
+            2,
+          )}\n\nActual:\n` +
+          `${JSON.stringify(args.actualBody, null, 2)}`
+        );
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/quote/" +
+          this.context.expects.sep38QuoteResponseObj.id,
+        {
+          headers: { Authorization: `Bearer ${this.context.expects.token}` },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const quoteResponse = await makeRequest(
+      networkCall,
+      200,
+      result,
+      "application/json",
+    );
+    if (!quoteResponse) return result;
+    const validationResult = validate(quoteResponse, quoteSchema);
+    if (validationResult.errors.length !== 0) {
+      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
+        errors: validationResult.errors.join("\n"),
+      });
+      return result;
+    }
+    if (
+      !isDeepStrictEqual(
+        this.context.expects.sep38QuoteResponseObj,
+        quoteResponse,
+      )
+    ) {
+      result.failure = makeFailure(this.failureModes.QUOTE_BODY_DOESNT_MATCH, {
+        expectedBody: this.context.expects.sep38QuoteResponseObj,
+        actualBody: quoteResponse,
+      });
+      return result;
+    }
+    return result;
+  },
+};
+
+export const returnsNotFound: Test = {
+  sep: 38,
+  assertion: "returns 404 for unknown quote ID",
+  group: "GET /quote",
+  dependencies: [returnsValidJwt, hasQuoteServer],
+  context: {
+    expects: {
+      token: undefined,
+      quoteServerUrl: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_ERROR_SCHEMA: {
+      name: "invalid error schema",
+      text(_args: any): string {
+        return "All error responses should contain a JSON body with an 'error' key-value pair";
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl + "/quote/" + "18e413284",
+        {
+          headers: { Authorization: `Bearer ${this.context.expects.token}` },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const quoteResponse = await makeRequest(
+      networkCall,
+      404,
+      result,
+      "application/json",
+    );
+    if (!quoteResponse) return result;
+    if (!quoteResponse.error) {
+      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
+      return result;
+    }
+    return result;
+  },
+};
+
+export default [requiresJwt, canFetchQuote, returnsNotFound];

--- a/@stellar/anchor-tests/src/tests/sep38/info.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/info.ts
@@ -1,0 +1,1 @@
+export default [];

--- a/@stellar/anchor-tests/src/tests/sep38/info.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/info.ts
@@ -1,1 +1,160 @@
-export default [];
+import { Request } from "node-fetch";
+import { validate } from "jsonschema";
+import { Keypair } from "stellar-sdk";
+
+import { Test, Result, Config, NetworkCall } from "../../types";
+import { genericFailures, makeFailure } from "../../helpers/failure";
+import { makeRequest } from "../../helpers/request";
+import { hasQuoteServer } from "./toml";
+import { infoSchema } from "../../schemas/sep38";
+
+export const hasValidInfoSchema: Test = {
+  assertion: "matches the expected schema",
+  sep: 38,
+  group: "GET /info",
+  dependencies: [hasQuoteServer],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+    },
+    provides: {
+      sep38InfoObj: undefined,
+      sep38StellarAsset: undefined,
+    },
+  },
+  failureModes: {
+    INVALID_SCHEMA: {
+      name: "invalid schema",
+      text(args: any): string {
+        return (
+          "The response body from GET /info does not match the schema defined by the protocol. " +
+          "Errors:\n\n" +
+          `${args.errors}`
+        );
+      },
+      links: {
+        "Info Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#get-info",
+      },
+    },
+    INVALID_ASSET_VALUE: {
+      name: "invalid 'asset' value",
+      text(args: any): string {
+        return `The 'asset' value ${args.asset} does not comply with SEP-38 Asset Identification Format`;
+      },
+      links: {
+        "Asset Identification Format":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#asset-identification-format",
+      },
+    },
+    INVALID_STELLAR_ASSET_SCHEMA: {
+      name: "invalid schema for Stellar asset",
+      text(args: any): string {
+        return `The stellar asset ${args.asset} object should only contain the 'asset' key-value pair.`;
+      },
+      links: {
+        "Info Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#get-info",
+      },
+    },
+    NO_STELLAR_ASSETS: {
+      name: "no Stellar assets",
+      text(_args: any): string {
+        return "No Stellar assets were found in the 'assets' list";
+      },
+    },
+    NO_OFFCHAIN_ASSETS: {
+      name: "no off-chain assets",
+      text(_args: any): string {
+        return "No off-chain assets were found in the 'assets' list";
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const getInfoCall: NetworkCall = {
+      request: new Request(this.context.expects.quoteServerUrl + "/info"),
+    };
+    result.networkCalls.push(getInfoCall);
+    this.context.provides.sep38InfoObj = await makeRequest(
+      getInfoCall,
+      200,
+      result,
+      "application/json",
+    );
+    if (!this.context.provides.sep38InfoObj) return result;
+    const validationResult = validate(
+      this.context.provides.sep38InfoObj,
+      infoSchema,
+    );
+    if (validationResult.errors.length !== 0) {
+      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
+        errors: validationResult.errors.join("\n"),
+      });
+      return result;
+    }
+    if (this.context.provides.sep38InfoObj.assets.length === 0) {
+      result.failure = makeFailure(this.failureModes.NO_ASSETS);
+    }
+    let offChainAssetFound = false;
+    for (const asset of this.context.provides.sep38InfoObj.assets) {
+      if (asset.asset.startsWith("stellar")) {
+        const parts = asset.asset.split(":");
+        const failure = makeFailure(this.failureModes.INVALID_ASSET_VALUE, {
+          asset: asset.asset,
+        });
+        if (parts.length !== 3) {
+          result.failure = failure;
+          return result;
+        }
+        try {
+          Keypair.fromPublicKey(parts[2]);
+        } catch {
+          result.failure = failure;
+          return result;
+        }
+        if (
+          asset.country_codes ||
+          asset.sell_delivery_methods ||
+          asset.buy_delivery_methods
+        ) {
+          result.failure = makeFailure(
+            this.failureModes.INVALID_STELLAR_ASSET_SCHEMA,
+            {
+              asset: asset.asset,
+            },
+          );
+          return result;
+        }
+        if (!this.context.provides.sep38StellarAsset)
+          this.context.provides.sep38StellarAsset = asset.asset;
+      } else if (asset.asset.startsWith("iso4217")) {
+        offChainAssetFound = true;
+        const parts = asset.asset.split(":");
+        if (parts.length !== 2) {
+          result.failure = makeFailure(this.failureModes.INVALID_ASSET_VALUE, {
+            asset: asset.asset,
+          });
+          return result;
+        }
+      } else {
+        result.failure = makeFailure(this.failureModes.INVALID_ASSET_VALUE, {
+          asset: asset.asset,
+        });
+        return result;
+      }
+    }
+    if (!this.context.provides.sep38StellarAsset) {
+      result.failure = makeFailure(this.failureModes.NO_STELLAR_ASSETS);
+      return result;
+    }
+    if (!offChainAssetFound) {
+      result.failure = makeFailure(this.failureModes.NO_OFFCHAIN_ASSETS);
+      return result;
+    }
+    return result;
+  },
+};
+
+export default [hasValidInfoSchema];

--- a/@stellar/anchor-tests/src/tests/sep38/postQuote.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/postQuote.ts
@@ -1,0 +1,285 @@
+import { Request } from "node-fetch";
+import { validate } from "jsonschema";
+
+import { Test, Result, Config, NetworkCall } from "../../types";
+import { hasQuoteServer } from "./toml";
+import { genericFailures, makeFailure } from "../../helpers/failure";
+import { makeRequest } from "../../helpers/request";
+import { quoteSchema } from "../../schemas/sep38";
+import { returnsValidJwt } from "../sep10/tests";
+
+export const requiresJwt: Test = {
+  sep: 38,
+  assertion: "requires a SEP-10 JWT",
+  group: "POST /quote",
+  dependencies: [returnsValidJwt, hasQuoteServer],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      sep38OffChainAsset: undefined,
+      sep38OffChainAssetDecimals: undefined,
+      sep38OffChainAssetBuyDeliveryMethod: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_ERROR_SCHEMA: {
+      name: "invalid error schema",
+      text(_args: any): string {
+        return "All error responses should contain a JSON body with an 'error' key-value pair";
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const requestBody: any = {
+      sell_asset: this.context.expects.sep38StellarAsset,
+      buy_asset: this.context.expects.sep38OffChainAsset,
+      sell_amount: "100",
+    };
+    if (this.context.expects.sep38BuyDeliveryMethod)
+      requestBody.buy_delivery_method =
+        this.context.expects.sep38OffChainAssetBuyDeliveryMethod;
+    const networkCall: NetworkCall = {
+      request: new Request(this.context.expects.quoteServerUrl + "/quote", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      }),
+    };
+    result.networkCalls.push(networkCall);
+    const quoteResponse = await makeRequest(
+      networkCall,
+      403,
+      result,
+      "application/json",
+    );
+    if (!quoteResponse) return result;
+    if (!quoteResponse.error) {
+      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
+      return result;
+    }
+    return result;
+  },
+};
+
+export const canCreateQuote: Test = {
+  sep: 38,
+  assertion: "can create a quote",
+  group: "POST /quote",
+  dependencies: [returnsValidJwt, hasQuoteServer],
+  context: {
+    expects: {
+      token: undefined,
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      sep38OffChainAsset: undefined,
+      sep38OffChainAssetDecimals: undefined,
+      sep38OffChainAssetBuyDeliveryMethod: undefined,
+    },
+    provides: {
+      sep38QuoteResponseObj: undefined,
+    },
+  },
+  failureModes: {
+    INVALID_SCHEMA: {
+      name: "invalid POST /quote response schema",
+      text(args: any): string {
+        return (
+          "The response body from POST /quote does not match the schema defined by the protocol. " +
+          "Errors:\n\n" +
+          `${args.errors}`
+        );
+      },
+      links: {
+        "POST /quote Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-3",
+      },
+    },
+    INVALID_NUMBER: {
+      name: "invalid number",
+      text(_args: any): string {
+        return "One of the amount values returned in the response cannot be parsed as numbers.";
+      },
+      links: {
+        "POST /quote Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-3",
+      },
+    },
+    ASSETS_DONT_MATCH: {
+      name: "assets don't match parameters",
+      text(args: any): string {
+        return (
+          "The assets in the response do not match the parameters sent.\n\n" +
+          `Requested sell asset: ${args.expectedSellAsset}\n` +
+          `Sell asset from response: ${args.actualSellAsset}\n` +
+          `Request buy asset: ${args.expectedBuyAsset}\n` +
+          `Buy asset from response: ${args.actualBuyAsset}\n`
+        );
+      },
+      links: {
+        "POST /quote Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-3",
+      },
+    },
+    AMOUNT_DOESNT_MATCH: {
+      name: "'sell_amount' doesn't match request parameter",
+      text(args: any): string {
+        return (
+          "The sell amount returned in the response doesn't match the amount requested:\n\n" +
+          `Requested sell asset amount: ${args.expectedSellAmount}\n` +
+          `Sell asset amount from response: ${args.actualSellAmount}`
+        );
+      },
+      links: {
+        "POST /quote Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-3",
+      },
+    },
+    INVALID_EXPIRATION: {
+      name: "invalid 'expires_at'",
+      text(_args: any): string {
+        return "The expiration ('expires_at') returned is not in the future.";
+      },
+      links: {
+        "POST /quote Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-3",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const requestBody: any = {
+      sell_asset: this.context.expects.sep38StellarAsset,
+      buy_asset: this.context.expects.sep38OffChainAsset,
+      sell_amount: "100",
+    };
+    if (this.context.expects.sep38OffChainAssetBuyDeliveryMethod !== undefined)
+      requestBody.buy_delivery_method =
+        this.context.expects.sep38OffChainAssetBuyDeliveryMethod;
+    const networkCall: NetworkCall = {
+      request: new Request(this.context.expects.quoteServerUrl + "/quote", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.context.expects.token}`,
+        },
+        body: JSON.stringify(requestBody),
+      }),
+    };
+    result.networkCalls.push(networkCall);
+    const quoteResponse = await makeRequest(
+      networkCall,
+      201,
+      result,
+      "application/json",
+    );
+    if (!quoteResponse) return result;
+    const validationResult = validate(quoteResponse, quoteSchema);
+    if (validationResult.errors.length !== 0) {
+      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
+        errors: validationResult.errors.join("\n"),
+      });
+      return result;
+    }
+    if (
+      !Number(quoteResponse.buy_amount) ||
+      !Number(quoteResponse.sell_amount) ||
+      !Number(quoteResponse.price)
+    ) {
+      result.failure = makeFailure(this.failureModes.INVALID_NUMBER);
+      return result;
+    }
+    if (
+      quoteResponse.sell_asset !== this.context.expects.sep38StellarAsset ||
+      quoteResponse.buy_asset !== this.context.expects.sep38OffChainAsset
+    ) {
+      result.failure = makeFailure(this.failureModes.ASSETS_DONT_MATCH, {
+        expectedSellAsset: this.context.expects.sep38StellarAsset,
+        actualSellAsset: quoteResponse.sell_asset,
+        expectedBuyAsset: this.context.expects.sep38OffChainAsset,
+        actualBuyAsset: quoteResponse.buy_asset,
+      });
+      return result;
+    }
+    if (Number(quoteResponse.sell_amount) !== 100) {
+      result.failure = makeFailure(this.failureModes.AMOUNT_DOESNT_MATCH, {
+        expectedSellAmount: "100",
+        actualSellAmount: quoteResponse.sell_amount,
+      });
+      return result;
+    }
+    if (Date.now() >= Date.parse(quoteResponse.expires_at)) {
+      result.failure = makeFailure(this.failureModes.INVALID_EXPIRATION);
+      return result;
+    }
+    this.context.provides.sep38QuoteResponseObj = quoteResponse;
+    return result;
+  },
+};
+
+export const amountsAreValid: Test = {
+  sep: 38,
+  assertion: "amounts are valid",
+  group: "POST /quote",
+  dependencies: [canCreateQuote],
+  context: {
+    expects: {
+      sep38OffChainAssetDecimals: undefined,
+      sep38QuoteResponseObj: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_AMOUNTS: {
+      name: "amounts and price don't match",
+      text(args: any): string {
+        return `The amounts returned in the response do not add up. ${args.buyAmount} * ${args.price} != ${args.sellAmount}`;
+      },
+      links: {
+        "POST /quote Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-3",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const roundingMultiplier = Math.pow(
+      10,
+      Number(this.context.expects.sep38OffChainAssetDecimals),
+    );
+    if (
+      Math.round(
+        (Number(this.context.expects.sep38QuoteResponseObj.sell_amount) /
+          Number(this.context.expects.sep38QuoteResponseObj.price)) *
+          roundingMultiplier,
+      ) /
+        roundingMultiplier !==
+      Math.round(
+        Number(this.context.expects.sep38QuoteResponseObj.buy_amount) *
+          roundingMultiplier,
+      ) /
+        roundingMultiplier
+    ) {
+      result.failure = makeFailure(this.failureModes.INVALID_AMOUNTS, {
+        buyAmount: this.context.expects.sep38QuoteResponseObj.buy_amount,
+        sellAmount: this.context.expects.sep38QuoteResponseObj.sell_amount,
+        price: this.context.expects.sep38QuoteResponseObj.price,
+      });
+      return result;
+    }
+    return result;
+  },
+};
+
+export default [requiresJwt, canCreateQuote, amountsAreValid];

--- a/@stellar/anchor-tests/src/tests/sep38/price.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/price.ts
@@ -1,0 +1,1 @@
+export default [];

--- a/@stellar/anchor-tests/src/tests/sep38/price.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/price.ts
@@ -91,6 +91,7 @@ export const returnsValidResponse: Test = {
       sep38StellarAsset: undefined,
       sep38OffChainAsset: undefined,
       sep38OffChainAssetDecimals: undefined,
+      sep38OffChainAssetBuyDeliveryMethod: undefined,
     },
     provides: {
       sep38SellAmount: undefined,
@@ -100,7 +101,7 @@ export const returnsValidResponse: Test = {
   },
   failureModes: {
     INVALID_SCHEMA: {
-      name: "invalid GET /prices schema",
+      name: "invalid GET /price schema",
       text(args: any): string {
         return (
           "The response body from GET /price does not match the schema defined by the protocol. " +
@@ -127,15 +128,19 @@ export const returnsValidResponse: Test = {
   },
   async run(_config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
+    const requestBody: any = {
+      sell_asset: this.context.expects.sep38StellarAsset,
+      buy_asset: this.context.expects.sep38OffChainAsset,
+      sell_amount: "100",
+    };
+    if (this.context.expects.sep38OffChainAssetBuyDeliveryMethod !== undefined)
+      requestBody.buy_delivery_method =
+        this.context.expects.sep38OffChainAssetBuyDeliveryMethod;
     const networkCall: NetworkCall = {
       request: new Request(
         this.context.expects.quoteServerUrl +
           "/price?" +
-          new URLSearchParams({
-            sell_asset: this.context.expects.sep38StellarAsset,
-            buy_asset: this.context.expects.sep38OffChainAsset,
-            sell_amount: "100",
-          }),
+          new URLSearchParams(requestBody),
         {
           headers: {
             Authorization: `Bearer ${this.context.expects.token}`,
@@ -229,244 +234,6 @@ export const amountsAreValid: Test = {
   },
 };
 
-export const requiresSellAsset: Test = {
-  sep: 38,
-  assertion: "requires 'sell_asset' parameter",
-  group: "GET /price",
-  dependencies: [returnsValidResponse],
-  context: {
-    expects: {
-      token: undefined,
-      quoteServerUrl: undefined,
-      sep38OffChainAsset: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/price?" +
-          new URLSearchParams({
-            buy_asset: this.context.expects.sep38OffChainAsset,
-            sell_amount: "100",
-          }),
-        {
-          headers: {
-            Authorization: `Bearer ${this.context.expects.token}`,
-          },
-        },
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const priceResponse = await makeRequest(
-      networkCall,
-      400,
-      result,
-      "application/json",
-    );
-    if (!priceResponse) return result;
-    if (!priceResponse.error) {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
-    }
-    return result;
-  },
-};
-
-export const validatesSellAsset: Test = {
-  sep: 38,
-  assertion: "validates 'sell_asset' parameter",
-  group: "GET /price",
-  dependencies: [returnsValidResponse],
-  context: {
-    expects: {
-      token: undefined,
-      quoteServerUrl: undefined,
-      sep38OffChainAsset: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/price?" +
-          new URLSearchParams({
-            sell_asset: "test",
-            buy_asset: this.context.expects.sep38OffChainAsset,
-            sell_amount: "100",
-          }),
-        {
-          headers: {
-            Authorization: `Bearer ${this.context.expects.token}`,
-          },
-        },
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const priceResponse = await makeRequest(
-      networkCall,
-      400,
-      result,
-      "application/json",
-    );
-    if (!priceResponse) return result;
-    if (!priceResponse.error) {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
-    }
-    return result;
-  },
-};
-
-export const requiresBuyAsset: Test = {
-  sep: 38,
-  assertion: "requires 'buy_asset' parameter",
-  group: "GET /price",
-  dependencies: [returnsValidResponse],
-  context: {
-    expects: {
-      token: undefined,
-      quoteServerUrl: undefined,
-      sep38StellarAsset: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/price?" +
-          new URLSearchParams({
-            sell_asset: this.context.expects.sep38StellarAsset,
-            sell_amount: "100",
-          }),
-        {
-          headers: {
-            Authorization: `Bearer ${this.context.expects.token}`,
-          },
-        },
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const priceResponse = await makeRequest(
-      networkCall,
-      400,
-      result,
-      "application/json",
-    );
-    if (!priceResponse) return result;
-    if (!priceResponse.error) {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
-    }
-    return result;
-  },
-};
-
-export const validatesBuyAsset: Test = {
-  sep: 38,
-  assertion: "validates 'buy_asset' parameter",
-  group: "GET /price",
-  dependencies: [returnsValidResponse],
-  context: {
-    expects: {
-      token: undefined,
-      quoteServerUrl: undefined,
-      sep38StellarAsset: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/price?" +
-          new URLSearchParams({
-            sell_asset: this.context.expects.sep38StellarAsset,
-            buy_asset: "test",
-            sell_amount: "100",
-          }),
-        {
-          headers: {
-            Authorization: `Bearer ${this.context.expects.token}`,
-          },
-        },
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const priceResponse = await makeRequest(
-      networkCall,
-      400,
-      result,
-      "application/json",
-    );
-    if (!priceResponse) return result;
-    if (!priceResponse.error) {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
-    }
-    return result;
-  },
-};
-
 export const acceptsBuyAmounts: Test = {
   assertion: "accepts 'buy_amount' parameter",
   sep: 38,
@@ -478,6 +245,7 @@ export const acceptsBuyAmounts: Test = {
       quoteServerUrl: undefined,
       sep38StellarAsset: undefined,
       sep38OffChainAsset: undefined,
+      sep38OffChainAssetBuyDeliveryMethod: undefined,
     },
     provides: {},
   },
@@ -486,15 +254,95 @@ export const acceptsBuyAmounts: Test = {
   },
   async run(_config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
+    const requestBody: any = {
+      sell_asset: this.context.expects.sep38StellarAsset,
+      buy_asset: this.context.expects.sep38OffChainAsset,
+      buy_amount: "100",
+    };
+    if (this.context.expects.sep38OffChainAssetBuyDeliveryMethod !== undefined)
+      requestBody.buy_delivery_method =
+        this.context.expects.sep38OffChainAssetBuyDeliveryMethod;
     const networkCall: NetworkCall = {
       request: new Request(
         this.context.expects.quoteServerUrl +
           "/price?" +
-          new URLSearchParams({
-            sell_asset: this.context.expects.sep38StellarAsset,
-            buy_asset: this.context.expects.sep38OffChainAsset,
-            buy_amount: "100",
-          }),
+          new URLSearchParams(requestBody),
+        {
+          headers: {
+            Authorization: `Bearer ${this.context.expects.token}`,
+          },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const priceResponse = await makeRequest(
+      networkCall,
+      200,
+      result,
+      "application/json",
+    );
+    if (!priceResponse) return result;
+    const validationResult = validate(priceResponse, priceSchema);
+    if (validationResult.errors.length !== 0) {
+      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
+        errors: validationResult.errors.join("\n"),
+      });
+      return result;
+    }
+    return result;
+  },
+};
+
+export const deliveryMethodIsOptional: Test = {
+  assertion: "specifying delivery method is optional",
+  sep: 38,
+  group: "GET /price",
+  dependencies: [returnsValidResponse],
+  context: {
+    expects: {
+      token: undefined,
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      sep38OffChainAsset: undefined,
+      sep38OffChainAssetBuyDeliveryMethod: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_SCHEMA: {
+      name: "invalid GET /price schema",
+      text(args: any): string {
+        return (
+          "The response body from GET /price does not match the schema defined by the protocol. " +
+          "Errors:\n\n" +
+          `${args.errors}`
+        );
+      },
+      links: {
+        "GET /price Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-2",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    if (!this.context.expects.sep38OffChainAssetBuyDeliveryMethod) {
+      // no buy delivery methods were specified for this off-chain asset
+      // so we've already made valid requests without a delivery method
+      // parameter value
+      return result;
+    }
+    const requestBody: any = {
+      sell_asset: this.context.expects.sep38StellarAsset,
+      buy_asset: this.context.expects.sep38OffChainAsset,
+      sell_amount: "100",
+    };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/price?" +
+          new URLSearchParams(requestBody),
         {
           headers: {
             Authorization: `Bearer ${this.context.expects.token}`,
@@ -525,9 +373,6 @@ export default [
   requiresJwt,
   returnsValidResponse,
   amountsAreValid,
-  requiresSellAsset,
-  validatesSellAsset,
-  requiresBuyAsset,
-  validatesBuyAsset,
   acceptsBuyAmounts,
+  deliveryMethodIsOptional,
 ];

--- a/@stellar/anchor-tests/src/tests/sep38/price.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/price.ts
@@ -1,1 +1,179 @@
-export default [];
+import { Request } from "node-fetch";
+import { URLSearchParams } from "url";
+import { validate } from "jsonschema";
+
+import { Test, Result, Config, NetworkCall } from "../../types";
+import { hasQuoteServer } from "./toml";
+import { genericFailures, makeFailure } from "../../helpers/failure";
+import { makeRequest } from "../../helpers/request";
+import { priceSchema } from "../../schemas/sep38";
+import { returnsValidJwt } from "../sep10/tests";
+
+export const requiresJwt: Test = {
+  sep: 38,
+  assertion: "requires SEP-10 authentication",
+  group: "GET /price",
+  dependencies: [hasQuoteServer],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_ERROR_SCHEMA: {
+      name: "invalid error schema",
+      text(_args: any): string {
+        return "All error responses should contain a JSON body with an 'error' key-value pair";
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/price?" +
+          new URLSearchParams({
+            sell_asset: this.context.provides.sep38StellarAsset,
+            buy_asset: this.context.provides.sep38OffChainAsset,
+            sell_amount: "100",
+          }),
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const errorJSON = await makeRequest(
+      networkCall,
+      403,
+      result,
+      "application/json",
+    );
+    if (!errorJSON) return result;
+    if (!errorJSON.error || typeof errorJSON.error !== "string") {
+      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
+      return result;
+    }
+    return result;
+  },
+};
+
+export const hasValidSchema: Test = {
+  sep: 38,
+  assertion: "has a valid response schema",
+  group: "GET /price",
+  dependencies: [returnsValidJwt, hasQuoteServer],
+  context: {
+    expects: {
+      token: undefined,
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      sep38OffChainAsset: undefined,
+      sep38OffChainAssetDecimals: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_SCHEMA: {
+      name: "invalid GET /prices schema",
+      text(args: any): string {
+        return (
+          "The response body from GET /price does not match the schema defined by the protocol. " +
+          "Errors:\n\n" +
+          `${args.errors}`
+        );
+      },
+      links: {
+        "GET /price Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-2",
+      },
+    },
+    INVALID_NUMBER: {
+      name: "invalid number",
+      text(_args: any): string {
+        return "One of the string values returned in the response cannot be parsed as numbers.";
+      },
+      links: {
+        "GET /price Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-2",
+      },
+    },
+    INVALID_AMOUNTS: {
+      name: "amounts and price don't match",
+      text(args: any): string {
+        return `The amounts returned in the response do not add up. ${args.buyAmount} * ${args.price} != ${args.sellAmount}`;
+      },
+      links: {
+        "GET /price Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-2",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/price?" +
+          new URLSearchParams({
+            sell_asset: this.context.expects.sep38StellarAsset,
+            buy_asset: this.context.expects.sep38OffChainAsset,
+            sell_amount: "100",
+          }),
+        {
+          headers: {
+            Authorization: `Bearer ${this.context.expects.token}`,
+          },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const priceResponse = await makeRequest(
+      networkCall,
+      200,
+      result,
+      "application/json",
+    );
+    if (!priceResponse) return result;
+    const validationResult = validate(priceResponse, priceSchema);
+    if (validationResult.errors.length !== 0) {
+      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
+        errors: validationResult.errors.join("\n"),
+      });
+      return result;
+    }
+    if (
+      !Number(priceResponse.buy_amount) ||
+      !Number(priceResponse.sell_amount) ||
+      !Number(priceResponse.price)
+    ) {
+      result.failure = makeFailure(this.failureModes.INVALID_NUMBER);
+      return result;
+    }
+    const roundingMultiplier = Math.pow(
+      10,
+      this.context.expects.sep38OffChainAssetDecimals,
+    );
+    if (
+      Number(priceResponse.sell_amount) / Number(priceResponse.price) !==
+      Math.round(Number(priceResponse.buy_amount) * roundingMultiplier) /
+        roundingMultiplier
+    ) {
+      result.failure = makeFailure(this.failureModes.INVALID_AMOUNTS, {
+        buyAmount: priceResponse.buy_amount,
+        sellAmount: priceResponse.sell_amount,
+        price: priceResponse.price,
+      });
+      return result;
+    }
+    return result;
+  },
+};
+
+export default [requiresJwt, hasValidSchema];

--- a/@stellar/anchor-tests/src/tests/sep38/prices.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/prices.ts
@@ -1,0 +1,1 @@
+export default [];

--- a/@stellar/anchor-tests/src/tests/sep38/prices.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/prices.ts
@@ -86,6 +86,7 @@ export const hasValidSchema: Test = {
   dependencies: [hasQuoteServer, returnsValidJwt],
   context: {
     expects: {
+      sep38InfoObj: undefined,
       quoteServerUrl: undefined,
       sep38StellarAsset: undefined,
       token: undefined,
@@ -93,6 +94,7 @@ export const hasValidSchema: Test = {
     provides: {
       sep38OffChainAsset: undefined,
       sep38OffChainAssetDecimals: undefined,
+      sep38OffChainAssetBuyDeliveryMethod: undefined,
     },
   },
   failureModes: {
@@ -189,231 +191,13 @@ export const hasValidSchema: Test = {
       pricesResponse.buy_assets[0].asset;
     this.context.provides.sep38OffChainAssetDecimals =
       pricesResponse.buy_assets[0].decimals;
-    return result;
-  },
-};
-
-export const requiresSellAsset: Test = {
-  sep: 38,
-  assertion: "requires 'sell_asset' parameter",
-  group: "GET /prices",
-  dependencies: [requiresJwt, returnsValidJwt],
-  context: {
-    expects: {
-      quoteServerUrl: undefined,
-      sep38StellarAsset: undefined,
-      token: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/prices?" +
-          new URLSearchParams({
-            sell_amount: "100",
-          }),
-        {
-          headers: { Authorization: `Bearer ${this.context.expects.token}` },
-        },
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const errorJSON = await makeRequest(
-      networkCall,
-      400,
-      result,
-      "application/json",
-    );
-    if (!errorJSON) return result;
-    if (!errorJSON.error || typeof errorJSON.error !== "string") {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
-    }
-    return result;
-  },
-};
-
-export const validatesSellAsset: Test = {
-  sep: 38,
-  assertion: "validates 'sell_asset' parameter",
-  group: "GET /prices",
-  dependencies: [requiresJwt, returnsValidJwt],
-  context: {
-    expects: {
-      quoteServerUrl: undefined,
-      sep38StellarAsset: undefined,
-      token: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/prices?" +
-          new URLSearchParams({
-            sell_asset: "test",
-            sell_amount: "100",
-          }),
-        {
-          headers: { Authorization: `Bearer ${this.context.expects.token}` },
-        },
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const errorJSON = await makeRequest(
-      networkCall,
-      400,
-      result,
-      "application/json",
-    );
-    if (!errorJSON) return result;
-    if (!errorJSON.error || typeof errorJSON.error !== "string") {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
-    }
-    return result;
-  },
-};
-
-export const requiresSellAmount: Test = {
-  sep: 38,
-  assertion: "requires 'sell_amount' parameter",
-  group: "GET /prices",
-  dependencies: [requiresJwt, returnsValidJwt],
-  context: {
-    expects: {
-      quoteServerUrl: undefined,
-      sep38StellarAsset: undefined,
-      token: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/prices?" +
-          new URLSearchParams({
-            sell_asset: this.context.provides.sep38StellarAsset,
-          }),
-        {
-          headers: { Authorization: `Bearer ${this.context.expects.token}` },
-        },
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const errorJSON = await makeRequest(
-      networkCall,
-      400,
-      result,
-      "application/json",
-    );
-    if (!errorJSON) return result;
-    if (!errorJSON.error || typeof errorJSON.error !== "string") {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
-    }
-    return result;
-  },
-};
-
-export const validatesSellAmount: Test = {
-  sep: 38,
-  assertion: "validates 'sell_amount' parameter",
-  group: "GET /prices",
-  dependencies: [requiresJwt, returnsValidJwt],
-  context: {
-    expects: {
-      quoteServerUrl: undefined,
-      sep38StellarAsset: undefined,
-      token: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/prices?" +
-          new URLSearchParams({
-            sell_asset: this.context.expects.sep38StellarAsset,
-            sell_amount: "test",
-          }),
-        {
-          headers: { Authorization: `Bearer ${this.context.expects.token}` },
-        },
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const errorJSON = await makeRequest(
-      networkCall,
-      400,
-      result,
-      "application/json",
-    );
-    if (!errorJSON) return result;
-    if (!errorJSON.error || typeof errorJSON.error !== "string") {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
+    this.context.provides.sep38OffChainAssetBuyDeliveryMethod = null;
+    for (const assetObj of this.context.expects.sep38InfoObj.assets) {
+      if (assetObj.asset == pricesResponse.buy_assets[0].asset) {
+        this.context.provides.sep38OffChainAssetBuyDeliveryMethod =
+          assetObj.buy_delivery_methods[0].name;
+        break;
+      }
     }
     return result;
   },
@@ -537,12 +321,85 @@ export const allowsOffChainSellAssets: Test = {
   },
 };
 
+export const deliveryMethodIsOptional: Test = {
+  assertion: "specifying delivery method is optional",
+  sep: 38,
+  group: "GET /prices",
+  dependencies: [hasValidSchema],
+  context: {
+    expects: {
+      token: undefined,
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      sep38OffChainAsset: undefined,
+      sep38OffChainAssetBuyDeliveryMethod: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_SCHEMA: {
+      name: "invalid GET /prices schema",
+      text(args: any): string {
+        return (
+          "The response body from GET /price does not match the schema defined by the protocol. " +
+          "Errors:\n\n" +
+          `${args.errors}`
+        );
+      },
+      links: {
+        "GET /price Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-2",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    if (!this.context.expects.sep38OffChainAssetBuyDeliveryMethod) {
+      // no buy delivery methods were specified for this off-chain asset
+      // so we've already made valid requests without a delivery method
+      // parameter value
+      return result;
+    }
+    const requestBody: any = {
+      sell_asset: this.context.expects.sep38StellarAsset,
+      buy_asset: this.context.expects.sep38OffChainAsset,
+      sell_amount: "100",
+    };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/prices?" +
+          new URLSearchParams(requestBody),
+        {
+          headers: {
+            Authorization: `Bearer ${this.context.expects.token}`,
+          },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const pricesResponse = await makeRequest(
+      networkCall,
+      200,
+      result,
+      "application/json",
+    );
+    if (!pricesResponse) return result;
+    const validationResult = validate(pricesResponse, pricesSchema);
+    if (validationResult.errors.length !== 0) {
+      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
+        errors: validationResult.errors.join("\n"),
+      });
+      return result;
+    }
+    return result;
+  },
+};
+
 export default [
   requiresJwt,
   hasValidSchema,
-  requiresSellAsset,
-  validatesSellAsset,
-  requiresSellAmount,
-  validatesSellAmount,
   allowsOffChainSellAssets,
+  deliveryMethodIsOptional,
 ];

--- a/@stellar/anchor-tests/src/tests/sep38/prices.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/prices.ts
@@ -1,10 +1,14 @@
 import { Request } from "node-fetch";
 import { URLSearchParams } from "url";
+import { validate } from "jsonschema";
+import { Keypair } from "stellar-sdk";
 
 import { Test, Result, Config, NetworkCall } from "../../types";
 import { genericFailures, makeFailure } from "../../helpers/failure";
 import { makeRequest } from "../../helpers/request";
 import { hasQuoteServer } from "./toml";
+import { returnsValidJwt } from "../sep10/tests";
+import { pricesSchema } from "../../schemas/sep38";
 
 export const requiresJwt: Test = {
   sep: 38,
@@ -59,4 +63,467 @@ export const requiresJwt: Test = {
   },
 };
 
-export default [requiresJwt];
+export const hasValidSchema: Test = {
+  sep: 38,
+  assertion: "has a valid response schema",
+  group: "GET /prices",
+  dependencies: [hasQuoteServer, returnsValidJwt],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      token: undefined,
+    },
+    provides: {
+      sep38OffChainAsset: undefined,
+      sep38OffChainAssetDecimals: undefined,
+    },
+  },
+  failureModes: {
+    NO_OFFCHAIN_ASSETS: {
+      name: "no off-chain assets listed",
+      text(args: any): string {
+        return `GET /prices didn't return any prices for Stellar asset ${args.asset}`;
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    INVALID_SCHEMA: {
+      name: "invalid GET /prices schema",
+      text(args: any): string {
+        return (
+          "The response body from GET /prices does not match the schema defined by the protocol. " +
+          "Errors:\n\n" +
+          `${args.errors}`
+        );
+      },
+      links: {
+        "GET /prices Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-1",
+      },
+    },
+    INVALID_ASSET_VALUE: {
+      name: "invalid 'asset' value",
+      text(args: any): string {
+        return `The 'asset' value ${args.asset} does not comply with SEP-38 Asset Identification Format`;
+      },
+      links: {
+        "Asset Identification Format":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#asset-identification-format",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/prices?" +
+          new URLSearchParams({
+            sell_asset: this.context.expects.sep38StellarAsset,
+            sell_amount: "100",
+          }),
+        {
+          headers: {
+            Authorization: `Bearer ${this.context.expects.token}`,
+          },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const pricesResponse = await makeRequest(
+      networkCall,
+      200,
+      result,
+      "application/json",
+    );
+    if (!pricesResponse) return result;
+    const validationResult = validate(pricesResponse, pricesSchema);
+    if (validationResult.errors.length !== 0) {
+      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
+        errors: validationResult.errors.join("\n"),
+      });
+      return result;
+    }
+    if (!pricesResponse.buy_assets) {
+      result.failure = makeFailure(this.failureModes.NO_OFFCHAIN_ASSETS, {
+        asset: this.context.expects.sep38StellarAsset,
+      });
+      return result;
+    }
+    for (const asset of pricesResponse.buy_assets) {
+      const parts = asset.asset.split(":");
+      if (parts.length !== 2 || parts[0] !== "iso4217") {
+        result.failure = makeFailure(this.failureModes.INVALID_ASSET_VALUE, {
+          asset: asset.asset,
+        });
+        return result;
+      }
+      if (!Number(asset.price)) {
+        result.failure = makeFailure(this.failureModes.INVALID_PRICE, {
+          price: asset.price,
+        });
+        return result;
+      }
+    }
+    this.context.provides.sep38OffChainAsset =
+      pricesResponse.buy_assets[0].asset;
+    this.context.provides.sep38OffChainAssetDecimals =
+      pricesResponse.buy_assets[0].decimals;
+    return result;
+  },
+};
+
+export const requiresSellAsset: Test = {
+  sep: 38,
+  assertion: "requires 'sell_asset' parameter",
+  group: "GET /prices",
+  dependencies: [requiresJwt, returnsValidJwt],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      token: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_ERROR_SCHEMA: {
+      name: "invalid error schema",
+      text(_args: any): string {
+        return "All error responses should contain a JSON body with an 'error' key-value pair";
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/prices?" +
+          new URLSearchParams({
+            sell_amount: "100",
+          }),
+        {
+          headers: { Authorization: `Bearer ${this.context.expects.token}` },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const errorJSON = await makeRequest(
+      networkCall,
+      400,
+      result,
+      "application/json",
+    );
+    if (!errorJSON) return result;
+    if (!errorJSON.error || typeof errorJSON.error !== "string") {
+      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
+      return result;
+    }
+    return result;
+  },
+};
+
+export const validatesSellAsset: Test = {
+  sep: 38,
+  assertion: "validates 'sell_asset' parameter",
+  group: "GET /prices",
+  dependencies: [requiresJwt, returnsValidJwt],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      token: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_ERROR_SCHEMA: {
+      name: "invalid error schema",
+      text(_args: any): string {
+        return "All error responses should contain a JSON body with an 'error' key-value pair";
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/prices?" +
+          new URLSearchParams({
+            sell_asset: "test",
+            sell_amount: "100",
+          }),
+        {
+          headers: { Authorization: `Bearer ${this.context.expects.token}` },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const errorJSON = await makeRequest(
+      networkCall,
+      400,
+      result,
+      "application/json",
+    );
+    if (!errorJSON) return result;
+    if (!errorJSON.error || typeof errorJSON.error !== "string") {
+      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
+      return result;
+    }
+    return result;
+  },
+};
+
+export const requiresSellAmount: Test = {
+  sep: 38,
+  assertion: "requires 'sell_amount' parameter",
+  group: "GET /prices",
+  dependencies: [requiresJwt, returnsValidJwt],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      token: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_ERROR_SCHEMA: {
+      name: "invalid error schema",
+      text(_args: any): string {
+        return "All error responses should contain a JSON body with an 'error' key-value pair";
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/prices?" +
+          new URLSearchParams({
+            sell_asset: this.context.provides.sep38StellarAsset,
+          }),
+        {
+          headers: { Authorization: `Bearer ${this.context.expects.token}` },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const errorJSON = await makeRequest(
+      networkCall,
+      400,
+      result,
+      "application/json",
+    );
+    if (!errorJSON) return result;
+    if (!errorJSON.error || typeof errorJSON.error !== "string") {
+      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
+      return result;
+    }
+    return result;
+  },
+};
+
+export const validatesSellAmount: Test = {
+  sep: 38,
+  assertion: "validates 'sell_amount' parameter",
+  group: "GET /prices",
+  dependencies: [requiresJwt, returnsValidJwt],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+      token: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_ERROR_SCHEMA: {
+      name: "invalid error schema",
+      text(_args: any): string {
+        return "All error responses should contain a JSON body with an 'error' key-value pair";
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/prices?" +
+          new URLSearchParams({
+            sell_asset: this.context.expects.sep38StellarAsset,
+            sell_amount: "test",
+          }),
+        {
+          headers: { Authorization: `Bearer ${this.context.expects.token}` },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const errorJSON = await makeRequest(
+      networkCall,
+      400,
+      result,
+      "application/json",
+    );
+    if (!errorJSON) return result;
+    if (!errorJSON.error || typeof errorJSON.error !== "string") {
+      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
+      return result;
+    }
+    return result;
+  },
+};
+
+export const allowsOffChainSellAssets: Test = {
+  sep: 38,
+  assertion: "allows off-chain assets as 'sell_asset'",
+  group: "GET /prices",
+  dependencies: [hasValidSchema],
+  context: {
+    expects: {
+      token: undefined,
+      sep38OffChainAsset: undefined,
+      quoteServerUrl: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    NO_OFFCHAIN_ASSETS: {
+      name: "no off-chain assets listed",
+      text(args: any): string {
+        return `GET /prices didn't return any prices for off-chain asset ${args.asset}`;
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    INVALID_SCHEMA: {
+      name: "invalid GET /prices schema",
+      text(args: any): string {
+        return (
+          "The response body from GET /prices does not match the schema defined by the protocol. " +
+          "Errors:\n\n" +
+          `${args.errors}`
+        );
+      },
+      links: {
+        "GET /prices Response":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-1",
+      },
+    },
+    INVALID_ASSET_VALUE: {
+      name: "invalid 'asset' value",
+      text(args: any): string {
+        return `The 'asset' value ${args.asset} does not comply with SEP-38 Asset Identification Format`;
+      },
+      links: {
+        "Asset Identification Format":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#asset-identification-format",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/prices?" +
+          new URLSearchParams({
+            sell_asset: this.context.expects.sep38OffChainAsset,
+            sell_amount: "100",
+          }),
+        {
+          headers: {
+            Authorization: `Bearer ${this.context.expects.token}`,
+          },
+        },
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const pricesResponse = await makeRequest(
+      networkCall,
+      200,
+      result,
+      "application/json",
+    );
+    if (!pricesResponse) return result;
+    const validationResult = validate(pricesResponse, pricesSchema);
+    if (validationResult.errors.length !== 0) {
+      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
+        errors: validationResult.errors.join("\n"),
+      });
+      return result;
+    }
+    if (!pricesResponse.buy_assets) {
+      result.failure = makeFailure(this.failureModes.NO_ONCHAIN_ASSETS, {
+        asset: this.context.expects.sep38OffChainAsset,
+      });
+      return result;
+    }
+    for (const asset of pricesResponse.buy_assets) {
+      const parts = asset.asset.split(":");
+      const invalidAssetFailure = makeFailure(
+        this.failureModes.INVALID_ASSET_VALUE,
+        { asset: asset.asset },
+      );
+      if (parts.length !== 3 || parts[0] !== "stellar") {
+        result.failure = invalidAssetFailure;
+        return result;
+      }
+      try {
+        Keypair.fromPublicKey(parts[2]);
+      } catch {
+        result.failure = invalidAssetFailure;
+        return result;
+      }
+      if (!Number(asset.price)) {
+        result.failure = makeFailure(this.failureModes.INVALID_PRICE, {
+          price: asset.price,
+        });
+        return result;
+      }
+    }
+    return result;
+  },
+};
+
+export default [
+  requiresJwt,
+  hasValidSchema,
+  requiresSellAsset,
+  validatesSellAsset,
+  requiresSellAmount,
+  validatesSellAmount,
+  allowsOffChainSellAssets,
+];

--- a/@stellar/anchor-tests/src/tests/sep38/prices.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/prices.ts
@@ -63,6 +63,22 @@ export const requiresJwt: Test = {
   },
 };
 
+/*
+ * Its possible that the anchor only supports converting off-chain
+ * assets to on-chain assets (deposit-only), in which case this
+ * test and its dependents would fail.
+ *
+ * However, this is less likely than the alternative, in which the
+ * anchor only converts on-chain assets to off-chain assets, because
+ * this is what SEP-31 receivers do.
+ *
+ * Therefore, we try using on-chain assets as 'sell_asset'. Ideally,
+ * we would try this and on 400 or an empty response, try using an
+ * off-chain asset as 'sell_asset' before failing.
+ *
+ * TODO: handle case where anchor only supports conversion in a
+ * single direction. This applies to other tests as well.
+ */
 export const hasValidSchema: Test = {
   sep: 38,
   assertion: "has a valid response schema",
@@ -403,6 +419,11 @@ export const validatesSellAmount: Test = {
   },
 };
 
+/*
+ * If the anchor is a SEP-31 receiver, it doesn't facilitate off-chain --> on-chain
+ * conversions. So this test will pass if no prices are returned when passing
+ * an off-chain asset as a 'sell_asset'.
+ */
 export const allowsOffChainSellAssets: Test = {
   sep: 38,
   assertion: "allows off-chain assets as 'sell_asset'",
@@ -486,9 +507,7 @@ export const allowsOffChainSellAssets: Test = {
       return result;
     }
     if (!pricesResponse.buy_assets) {
-      result.failure = makeFailure(this.failureModes.NO_ONCHAIN_ASSETS, {
-        asset: this.context.expects.sep38OffChainAsset,
-      });
+      // don't expect the anchor to support off-chain --> on-chain conversions
       return result;
     }
     for (const asset of pricesResponse.buy_assets) {

--- a/@stellar/anchor-tests/src/tests/sep38/prices.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/prices.ts
@@ -1,1 +1,62 @@
-export default [];
+import { Request } from "node-fetch";
+import { URLSearchParams } from "url";
+
+import { Test, Result, Config, NetworkCall } from "../../types";
+import { genericFailures, makeFailure } from "../../helpers/failure";
+import { makeRequest } from "../../helpers/request";
+import { hasQuoteServer } from "./toml";
+
+export const requiresJwt: Test = {
+  sep: 38,
+  assertion: "requires SEP-10 authentication",
+  group: "GET /prices",
+  dependencies: [hasQuoteServer],
+  context: {
+    expects: {
+      quoteServerUrl: undefined,
+      sep38StellarAsset: undefined,
+    },
+    provides: {},
+  },
+  failureModes: {
+    INVALID_ERROR_SCHEMA: {
+      name: "invalid error schema",
+      text(_args: any): string {
+        return "All error responses should contain a JSON body with an 'error' key-value pair";
+      },
+      links: {
+        "SEP-38 Errors":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
+      },
+    },
+    ...genericFailures,
+  },
+  async run(_config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    const networkCall: NetworkCall = {
+      request: new Request(
+        this.context.expects.quoteServerUrl +
+          "/prices?" +
+          new URLSearchParams({
+            sell_asset: this.context.provides.sep38StellarAsset,
+            sell_amount: "100",
+          }),
+      ),
+    };
+    result.networkCalls.push(networkCall);
+    const errorJSON = await makeRequest(
+      networkCall,
+      403,
+      result,
+      "application/json",
+    );
+    if (!errorJSON) return result;
+    if (!errorJSON.error || typeof errorJSON.error !== "string") {
+      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
+      return result;
+    }
+    return result;
+  },
+};
+
+export default [requiresJwt];

--- a/@stellar/anchor-tests/src/tests/sep38/quote.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/quote.ts
@@ -1,1 +1,0 @@
-export default [];

--- a/@stellar/anchor-tests/src/tests/sep38/quote.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/quote.ts
@@ -1,0 +1,1 @@
+export default [];

--- a/@stellar/anchor-tests/src/tests/sep38/tests.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/tests.ts
@@ -1,0 +1,7 @@
+import { default as tomlTests } from "./toml";
+import { default as infoTests } from "./info";
+import { default as priceTests } from "./price";
+import { default as pricesTests } from "./prices";
+import { default as quoteTests } from "./quote";
+
+export default tomlTests.concat(infoTests, pricesTests, priceTests, quoteTests);

--- a/@stellar/anchor-tests/src/tests/sep38/tests.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/tests.ts
@@ -2,6 +2,13 @@ import { default as tomlTests } from "./toml";
 import { default as infoTests } from "./info";
 import { default as priceTests } from "./price";
 import { default as pricesTests } from "./prices";
-import { default as quoteTests } from "./quote";
+import { default as postQuoteTests } from "./postQuote";
+import { default as getQuoteTests } from "./getQuote";
 
-export default tomlTests.concat(infoTests, pricesTests, priceTests, quoteTests);
+export default tomlTests.concat(
+  infoTests,
+  pricesTests,
+  priceTests,
+  postQuoteTests,
+  getQuoteTests,
+);

--- a/@stellar/anchor-tests/src/tests/sep38/toml.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/toml.ts
@@ -1,0 +1,65 @@
+import { Test, Result, Config } from "../../types";
+import { tomlExists } from "../sep1/tests";
+import { makeFailure } from "../../helpers/failure";
+
+export const hasQuoteServer: Test = {
+  assertion: "has QUOTE_SERVER attribute",
+  sep: 38,
+  group: "TOML Tests",
+  dependencies: [tomlExists],
+  context: {
+    expects: {
+      tomlObj: undefined,
+    },
+    provides: {
+      quoteServerUrl: undefined,
+    },
+  },
+  failureModes: {
+    QUOTE_SERVER_NOT_FOUND: {
+      name: "QUOTE_PAYMENT_SERVER not found",
+      text(_args: any): string {
+        return "The stellar.toml file does not have a valid QUOTE_PAYMENT_SERVER URL";
+      },
+      links: {
+        "SEP-38 Specification":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#specification",
+      },
+    },
+    NO_HTTPS: {
+      name: "no https",
+      text(_args: any): string {
+        return "The transfer server URL must use HTTPS";
+      },
+    },
+    ENDS_WITH_SLASH: {
+      name: "ends with slash",
+      text(_args: any): string {
+        return "The transfer server URL cannot end with a '/'";
+      },
+    },
+  },
+  async run(config: Config): Promise<Result> {
+    const result: Result = { networkCalls: [] };
+    this.context.provides.quoteServerUrl =
+      this.context.expects.tomlObj.QUOTE_SERVER;
+    if (!this.context.provides.quoteServerUrl) {
+      result.failure = makeFailure(this.failureModes.QUOTE_SERVER_NOT_FOUND);
+      return result;
+    }
+    if (
+      !this.context.provides.quoteServerUrl.startsWith("https") &&
+      !config.homeDomain.includes("localhost")
+    ) {
+      result.failure = makeFailure(this.failureModes.NO_HTTPS);
+      return result;
+    }
+    if (this.context.provides.quoteServerUrl.slice(-1) === "/") {
+      result.failure = makeFailure(this.failureModes.ENDS_WITH_SLASH);
+      return result;
+    }
+    return result;
+  },
+};
+
+export default [hasQuoteServer];

--- a/@stellar/anchor-tests/src/types.ts
+++ b/@stellar/anchor-tests/src/types.ts
@@ -4,7 +4,7 @@ import { Request, Response } from "node-fetch";
 /**
  * The [Stellar Ecosystem Proposals (SEPs)](https://github.com/stellar/stellar-protocol/tree/master/ecosystem) this library supports testing.
  */
-export type SEP = 1 | 6 | 10 | 12 | 24 | 31;
+export type SEP = 1 | 6 | 10 | 12 | 24 | 31 | 38;
 
 export interface Config {
   /**

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@types/node": "^14.14.41",
-    "@stellar/anchor-tests": "0.1.7",
+    "@stellar/anchor-tests": "0.2.0",
     "express": "^4.17.1",
     "socket.io": "^4.1.2",
     "tslib": "^2.2.0",

--- a/ui/src/components/TestCases/SepBlock.tsx
+++ b/ui/src/components/TestCases/SepBlock.tsx
@@ -53,6 +53,11 @@ const sepData: any = {
     source:
       "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md",
   },
+  38: {
+    name: "Request for Quote API",
+    source:
+      "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md",
+  },
 };
 
 export const SepBlock: React.FC<{

--- a/ui/src/components/TestCases/index.tsx
+++ b/ui/src/components/TestCases/index.tsx
@@ -8,7 +8,7 @@ import { SepBlock } from "./SepBlock";
 import { SepGroupTracker } from "./SepGroupTracker";
 import { TestBlock } from "./TestBlock";
 
-export const SepUIOrder = [1, 10, 12, 6, 24, 31];
+export const SepUIOrder = [1, 10, 12, 6, 24, 31, 38];
 
 const TestCasesWrapper = styled.section`
   margin-top: 2rem;

--- a/ui/src/views/TestRunner.tsx
+++ b/ui/src/views/TestRunner.tsx
@@ -36,6 +36,7 @@ const DROPDOWN_SEPS_MAP: Record<number, Array<number>> = {
   12: [1, 10, 12],
   24: [1, 10, 24],
   31: [1, 10, 12, 31],
+  38: [1, 10],
 };
 // SEPs that require the config file field to be rendered in UI
 const CONFIG_SEPS = [6, 12, 31];
@@ -281,6 +282,7 @@ export const TestRunner = () => {
       6: "TRANSFER_SERVER",
       24: "TRANSFER_SERVER_SEP0024",
       31: "DIRECT_PAYMENT_SERVER",
+      38: "QUOTE_SERVER",
     }[sep];
     if (!toml || !toml[tomlAttribute as string]) {
       setServerFailure(`The SEP-1 stellar.toml file has no ${tomlAttribute}.`);


### PR DESCRIPTION
resolves #71 

Adds tests to the test suite library for SEP-38. 

One major assumption made by these tests is that the anchor supports clients looking to sell Stellar assets in exchange for off-chain assets, which are the types of quotes used to facilitate SEP-6/24 withdrawals and SEP-31 sends. If the anchor doesn't support these types of quotes the suite will not be very useful to them. Ideally we would check which type of exchange is supported and use those types of quotes in the rest of the tests.