### PR TITLE
server: don't clone responses in serialization functions

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -43,7 +43,7 @@
     "jsonschema": "^1.4.0",
     "jsonwebtoken": "^8.5.1",
     "node-fetch": "^2.6.1",
-    "stellar-sdk": "~8.2.1",
+    "stellar-sdk": "~8.2.5",
     "toml": "^3.0.0",
     "tslib": "^2.2.0",
     "yargs": "^16.2.0"

--- a/server/src/serializers.ts
+++ b/server/src/serializers.ts
@@ -125,9 +125,7 @@ async function serializeNetworkCall(
   if (networkCall.request.body) {
     const contentType = networkCall.request.headers.get("Content-Type") || "";
     if (contentType.includes("application/json")) {
-      serializedNetworkCall.request.body = await networkCall.request
-        .clone()
-        .json();
+      serializedNetworkCall.request.body = await networkCall.request.json();
     } else if (contentType.includes("multipart/form-data")) {
       // TODO
     } else if (contentType.includes("application/x-www-form-urlencoded")) {
@@ -147,13 +145,9 @@ async function serializeNetworkCall(
       const contentType =
         networkCall.response.headers.get("Content-Type") || "";
       if (contentType.includes("application/json")) {
-        serializedNetworkCall.response.body = await networkCall.response
-          .clone()
-          .json();
+        serializedNetworkCall.response.body = await networkCall.response.json();
       } else {
-        serializedNetworkCall.response.body = await networkCall.response
-          .clone()
-          .text();
+        serializedNetworkCall.response.body = await networkCall.response.text();
       }
     }
   }


### PR DESCRIPTION
When running tests in the UI, tests are freezing because our test server is trying to clone HTTP response bodies using [clone()](https://developer.mozilla.org/en-US/docs/Web/API/Response/clone), which apparently has a [low size limit of about 16kB](https://github.com/node-fetch/node-fetch#custom-highwatermark). 

When anchors return response bodies larger than the limit, clone the body causes the process to hang. The recommended solution is to specify a larger limit, but this has to be done per-request. Because we have our `makeRequest()` helper that wouldn't be too big of a change, but we could always run into a response larger than our new limit.

Thankfully, we don't actually need to clone response bodies when serializing the results, since the response bodies will not be consumed again. So we'll just stop cloning these bodies, which will allow us to read the entire response.

This PR also updates the Stellar JS SDK to 8.2.5. 