### PR TITLE
SEP-38: update tests to make it compliant with the new version of SEP-38

### DIFF
--- a/@stellar/anchor-tests/src/tests/sep38/price.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/price.ts
@@ -9,60 +9,6 @@ import { makeRequest } from "../../helpers/request";
 import { priceSchema } from "../../schemas/sep38";
 import { returnsValidJwt } from "../sep10/tests";
 
-export const requiresJwt: Test = {
-  sep: 38,
-  assertion: "requires SEP-10 authentication",
-  group: "GET /price",
-  dependencies: [hasQuoteServer],
-  context: {
-    expects: {
-      quoteServerUrl: undefined,
-      sep38StellarAsset: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/price?" +
-          new URLSearchParams({
-            sell_asset: this.context.provides.sep38StellarAsset,
-            buy_asset: this.context.provides.sep38OffChainAsset,
-            sell_amount: "100",
-          }),
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const errorJSON = await makeRequest(
-      networkCall,
-      403,
-      result,
-      "application/json",
-    );
-    if (!errorJSON) return result;
-    if (!errorJSON.error || typeof errorJSON.error !== "string") {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
-    }
-    return result;
-  },
-};
-
 /*
  * Its possible that the anchor only supports converting off-chain
  * assets to on-chain assets (deposit-only), in which case this
@@ -370,7 +316,6 @@ export const deliveryMethodIsOptional: Test = {
 };
 
 export default [
-  requiresJwt,
   returnsValidResponse,
   amountsAreValid,
   acceptsBuyAmounts,

--- a/@stellar/anchor-tests/src/tests/sep38/prices.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/prices.ts
@@ -10,59 +10,6 @@ import { hasQuoteServer } from "./toml";
 import { returnsValidJwt } from "../sep10/tests";
 import { pricesSchema } from "../../schemas/sep38";
 
-export const requiresJwt: Test = {
-  sep: 38,
-  assertion: "requires SEP-10 authentication",
-  group: "GET /prices",
-  dependencies: [hasQuoteServer],
-  context: {
-    expects: {
-      quoteServerUrl: undefined,
-      sep38StellarAsset: undefined,
-    },
-    provides: {},
-  },
-  failureModes: {
-    INVALID_ERROR_SCHEMA: {
-      name: "invalid error schema",
-      text(_args: any): string {
-        return "All error responses should contain a JSON body with an 'error' key-value pair";
-      },
-      links: {
-        "SEP-38 Errors":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#errors",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(_config: Config): Promise<Result> {
-    const result: Result = { networkCalls: [] };
-    const networkCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.quoteServerUrl +
-          "/prices?" +
-          new URLSearchParams({
-            sell_asset: this.context.provides.sep38StellarAsset,
-            sell_amount: "100",
-          }),
-      ),
-    };
-    result.networkCalls.push(networkCall);
-    const errorJSON = await makeRequest(
-      networkCall,
-      403,
-      result,
-      "application/json",
-    );
-    if (!errorJSON) return result;
-    if (!errorJSON.error || typeof errorJSON.error !== "string") {
-      result.failure = makeFailure(this.failureModes.INVALID_ERROR_SCHEMA);
-      return result;
-    }
-    return result;
-  },
-};
-
 /*
  * Its possible that the anchor only supports converting off-chain
  * assets to on-chain assets (deposit-only), in which case this
@@ -398,7 +345,6 @@ export const deliveryMethodIsOptional: Test = {
 };
 
 export default [
-  requiresJwt,
   hasValidSchema,
   allowsOffChainSellAssets,
   deliveryMethodIsOptional,

--- a/@stellar/anchor-tests/src/tests/sep38/toml.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/toml.ts
@@ -3,7 +3,7 @@ import { tomlExists } from "../sep1/tests";
 import { makeFailure } from "../../helpers/failure";
 
 export const hasQuoteServer: Test = {
-  assertion: "has a QUOTE_SERVER attribute",
+  assertion: "has an ANCHOR_QUOTE_SERVER attribute",
   sep: 38,
   group: "TOML Tests",
   dependencies: [tomlExists],
@@ -16,10 +16,10 @@ export const hasQuoteServer: Test = {
     },
   },
   failureModes: {
-    QUOTE_SERVER_NOT_FOUND: {
-      name: "QUOTE_PAYMENT_SERVER not found",
+    ANCHOR_QUOTE_SERVER_NOT_FOUND: {
+      name: "ANCHOR_QUOTE_SERVER not found",
       text(_args: any): string {
-        return "The stellar.toml file does not have a valid QUOTE_PAYMENT_SERVER URL";
+        return "The stellar.toml file does not have a valid ANCHOR_QUOTE_SERVER URL";
       },
       links: {
         "SEP-38 Specification":
@@ -42,9 +42,9 @@ export const hasQuoteServer: Test = {
   async run(config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
     this.context.provides.quoteServerUrl =
-      this.context.expects.tomlObj.QUOTE_SERVER;
+      this.context.expects.tomlObj.ANCHOR_QUOTE_SERVER;
     if (!this.context.provides.quoteServerUrl) {
-      result.failure = makeFailure(this.failureModes.QUOTE_SERVER_NOT_FOUND);
+      result.failure = makeFailure(this.failureModes.ANCHOR_QUOTE_SERVER_NOT_FOUND);
       return result;
     }
     if (

--- a/ui/src/components/TestRunnerFields/HomeDomainField.tsx
+++ b/ui/src/components/TestRunnerFields/HomeDomainField.tsx
@@ -53,7 +53,7 @@ export const HomeDomainField = ({
       if (tomlObj.DIRECT_PAYMENT_SERVER) {
         newSupportedSeps.push(31);
       }
-      if (tomlObj.QUOTE_SERVER) {
+      if (tomlObj.ANCHOR_QUOTE_SERVER) {
         newSupportedSeps.push(38);
       }
       if (newSupportedSeps.length) {

--- a/ui/src/views/TestRunner.tsx
+++ b/ui/src/views/TestRunner.tsx
@@ -282,7 +282,7 @@ export const TestRunner = () => {
       6: "TRANSFER_SERVER",
       24: "TRANSFER_SERVER_SEP0024",
       31: "DIRECT_PAYMENT_SERVER",
-      38: "QUOTE_SERVER",
+      38: "ANCHOR_QUOTE_SERVER",
     }[sep];
     if (!toml || !toml[tomlAttribute as string]) {
       setServerFailure(`The SEP-1 stellar.toml file has no ${tomlAttribute}.`);


### PR DESCRIPTION
### What

Update tests to make it compliant with the new version of [SEP-38](https://stellar.org/protocol/sep-38):
* `QUOTE_SERVER` is actually meant to be `ANCHOR_QUOTE_SERVER`.
* Since https://github.com/stellar/stellar-protocol/pull/1144, only the /quote(s) endpoints require SEP-10 authentication.