### PR TITLE
SEP-12: remove 'account' param from requests

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep12/getCustomer.ts
+++ b/@stellar/anchor-tests/src/tests/sep12/getCustomer.ts
@@ -121,9 +121,7 @@ const newCustomerValidSchema: Test = {
     );
     if (!token) return result;
     const customerType = getCreateCustomerType(config);
-    const requestParamsObj: Record<string, string> = {
-      account: clientKeypair.publicKey(),
-    };
+    const requestParamsObj: Record<string, string> = {};
     if (customerType) requestParamsObj["type"] = customerType;
     const searchParams = new URLSearchParams(requestParamsObj);
     const getCustomerCall: NetworkCall = {
@@ -261,8 +259,8 @@ export const canFetchExistingCustomerById: Test = {
 };
 tests.push(canFetchExistingCustomerById);
 
-const canFetchExistingCustomerByAccount: Test = {
-  assertion: "can retrieve customer using 'account'",
+const canFetchExistingCustomerBySep10Token: Test = {
+  assertion: "can retrieve customer using SEP-10 token",
   sep: 12,
   group: getCustomerGroup,
   dependencies: [canCreateCustomer],
@@ -315,9 +313,7 @@ const canFetchExistingCustomerByAccount: Test = {
     }
     const result: Result = { networkCalls: [] };
     const customerType = getCreateCustomerType(config);
-    const requestParamsObj: Record<string, string> = {
-      account: this.context.expects.clientKeypair.publicKey(),
-    };
+    const requestParamsObj: Record<string, string> = {};
     if (customerType) requestParamsObj["type"] = customerType;
     const searchParams = new URLSearchParams(requestParamsObj);
     const getCustomerCall: NetworkCall = {
@@ -353,6 +349,6 @@ const canFetchExistingCustomerByAccount: Test = {
     return result;
   },
 };
-tests.push(canFetchExistingCustomerByAccount);
+tests.push(canFetchExistingCustomerBySep10Token);
 
 export default tests;

--- a/@stellar/anchor-tests/src/tests/sep12/putCustomer.ts
+++ b/@stellar/anchor-tests/src/tests/sep12/putCustomer.ts
@@ -117,7 +117,6 @@ export const canCreateCustomer: Test = {
     const putCustomerRequest = makeSep12Request({
       url: this.context.expects.kycServerUrl + "/customer",
       data: {
-        account: this.context.expects.clientKeypair.publicKey(),
         ...customerValues,
       },
       headers: {
@@ -295,7 +294,6 @@ export const differentMemosSameAccount: Test = {
     const sep12Request = makeSep12Request({
       url: this.context.expects.kycServerUrl + "/customer",
       data: {
-        account: this.context.provides.sendingAnchorClientKeypair.publicKey(),
         memo: this.context.provides.sendingCustomerMemo.value.toString(
           "base64",
         ),
@@ -327,7 +325,6 @@ export const differentMemosSameAccount: Test = {
     const receivingCustomerRequest = makeSep12Request({
       url: this.context.expects.kycServerUrl + "/customer",
       data: {
-        account: this.context.provides.sendingAnchorClientKeypair.publicKey(),
         memo: this.context.provides.receivingCustomerMemo.value.toString(
           "base64",
         ),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog documents all releases and included changes to the @stellar/ancho
 
 A breaking change will get clearly marked in this log.
 
+## [v0.4.0](https://github.com/stellar/stellar-anchor-tests/compare/v0.3.0...v0.4.0)
+
+### Update
+
+- SEP-12 tests no longer include the `account` request parameter since it has been deprecated. ([#82](https://github.com/stellar/stellar-anchor-tests/pull/82))
+
 ## [v0.3.0](https://github.com/stellar/stellar-anchor-tests/compare/v0.2.0...v0.3.0)
 
 ### Update


### PR DESCRIPTION
SEP-12 deprecated the `account` parameter in GET and PUT endpoints. This PR removes the usage of this parameter to so anchors can test against an updated client.