### PR TITLE
Make sure the process exits/fails if one or more tests don't pass

### DIFF
--- a/@stellar/anchor-tests/src/cli.ts
+++ b/@stellar/anchor-tests/src/cli.ts
@@ -133,5 +133,7 @@ let args = command.argv;
   }
   const endTime = Date.now();
   console.log(); // add new line between results and stats
-  printStats(getStats(testRuns), startTime, endTime);
+  const stats = getStats(testRuns);
+  printStats(stats, startTime, endTime);
+  if (stats.failed > 0) process.exit(1);
 })();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog documents all releases and included changes to the @stellar/ancho
 
 A breaking change will get clearly marked in this log.
 
+## [v0.4.1](https://github.com/stellar/stellar-anchor-tests/compare/v0.4.0...v0.4.1)
+
+### Update
+
+- If one or more tests don't pass, we make sure to fail the process. This way, CIs will understand the process was unsuccessful. ([#84](https://github.com/stellar/stellar-anchor-tests/pull/84))
+
 ## [v0.4.0](https://github.com/stellar/stellar-anchor-tests/compare/v0.3.0...v0.4.0)
 
 ### Update


### PR DESCRIPTION
### What

Make sure the process exits/fails if one or more tests don't pass.

### Why

Our CI was saying the tests were successful when they were actually not passing. In order for the CI to realize the command failed, it needs to exit/fail the process with `process.exit(1)`.