### PR TITLE
SEP-38: update SEP-38 tests based on stellar/stellar-protocol#1204

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep38.ts
+++ b/@stellar/anchor-tests/src/schemas/sep38.ts
@@ -76,12 +76,47 @@ export const pricesSchema = {
   required: ["buy_assets"],
 };
 
+const rateFeeSchema = {
+  type: "object",
+  properties: {
+    total: {
+      type: "string"
+    },
+    asset: {
+      type: "string"
+    },
+    details: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string"
+          },
+          description: {
+            type: "string"
+          },
+          amount: {
+            type: "string"
+          },
+        },
+        required: ["name", "amount"],
+      }
+    }
+  },
+  required: ["total", "asset"]
+}
+
 export const priceSchema = {
   type: "object",
   properties: {
     price: {
       type: "string",
     },
+    total_price: {
+      type: "string",
+    },
+    fee: rateFeeSchema,
     sell_amount: {
       type: "string",
     },
@@ -90,7 +125,7 @@ export const priceSchema = {
     },
   },
   additionalProperties: false,
-  required: ["price", "sell_amount", "buy_amount"],
+  required: ["price", "total_price", "sell_amount", "buy_amount", "fee"],
 };
 
 export const quoteSchema = {
@@ -106,6 +141,10 @@ export const quoteSchema = {
     price: {
       type: "string",
     },
+    total_price: {
+      type: "string",
+    },
+    fee: rateFeeSchema,
     sell_asset: {
       type: "string",
     },
@@ -124,6 +163,8 @@ export const quoteSchema = {
     "id",
     "expires_at",
     "price",
+    "total_price",
+    "fee",
     "sell_asset",
     "buy_asset",
     "sell_amount",

--- a/@stellar/anchor-tests/src/tests/sep38/postQuote.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/postQuote.ts
@@ -42,6 +42,7 @@ export const requiresJwt: Test = {
       sell_asset: this.context.expects.sep38StellarAsset,
       buy_asset: this.context.expects.sep38OffChainAsset,
       sell_amount: "100",
+      context: "sep31",
     };
     if (this.context.expects.sep38BuyDeliveryMethod)
       requestBody.buy_delivery_method =
@@ -162,6 +163,7 @@ export const canCreateQuote: Test = {
       sell_asset: this.context.expects.sep38StellarAsset,
       buy_asset: this.context.expects.sep38OffChainAsset,
       sell_amount: "100",
+      context: "sep31",
     };
     if (this.context.expects.sep38OffChainAssetBuyDeliveryMethod !== undefined)
       requestBody.buy_delivery_method =

--- a/@stellar/anchor-tests/src/tests/sep38/price.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/price.ts
@@ -78,6 +78,7 @@ export const returnsValidResponse: Test = {
       sell_asset: this.context.expects.sep38StellarAsset,
       buy_asset: this.context.expects.sep38OffChainAsset,
       sell_amount: "100",
+      context: "sep31",
     };
     if (this.context.expects.sep38OffChainAssetBuyDeliveryMethod !== undefined)
       requestBody.buy_delivery_method =
@@ -145,8 +146,8 @@ export const amountsAreValid: Test = {
         return `The amounts returned in the response do not add up. ${args.buyAmount} * ${args.price} != ${args.sellAmount}`;
       },
       links: {
-        "GET /price Response":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#response-2",
+        "Price formulas":
+          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#price-formulas",
       },
     },
     ...genericFailures,
@@ -204,6 +205,7 @@ export const acceptsBuyAmounts: Test = {
       sell_asset: this.context.expects.sep38StellarAsset,
       buy_asset: this.context.expects.sep38OffChainAsset,
       buy_amount: "100",
+      context: "sep31",
     };
     if (this.context.expects.sep38OffChainAssetBuyDeliveryMethod !== undefined)
       requestBody.buy_delivery_method =
@@ -283,6 +285,7 @@ export const deliveryMethodIsOptional: Test = {
       sell_asset: this.context.expects.sep38StellarAsset,
       buy_asset: this.context.expects.sep38OffChainAsset,
       sell_amount: "100",
+      context: "sep31",
     };
     const networkCall: NetworkCall = {
       request: new Request(

--- a/@stellar/anchor-tests/src/tests/sep38/prices.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/prices.ts
@@ -121,7 +121,11 @@ export const hasValidSchema: Test = {
     }
     for (const asset of pricesResponse.buy_assets) {
       const parts = asset.asset.split(":");
-      if (parts.length !== 2 || parts[0] !== "iso4217") {
+      
+      const notValidFiat = parts.length === 2 && parts[0] !== "iso4217";
+      const notValidStellar = parts.length === 3 && parts[0] !== "stellar";
+      const notValidAtAll = parts.length < 2 || parts.length > 3;
+      if (notValidFiat || notValidStellar || notValidAtAll) {
         result.failure = makeFailure(this.failureModes.INVALID_ASSET_VALUE, {
           asset: asset.asset,
         });

--- a/@stellar/anchor-tests/src/tests/sep38/tests.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/tests.ts
@@ -1,7 +1,7 @@
 import { default as tomlTests } from "./toml";
 import { default as infoTests } from "./info";
-import { default as priceTests } from "./price";
 import { default as pricesTests } from "./prices";
+import { default as priceTests } from "./price";
 import { default as postQuoteTests } from "./postQuote";
 import { default as getQuoteTests } from "./getQuote";
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ A breaking change will get clearly marked in this log.
 
 ### Update
 
-- SEP-38 tests now use the `context` parameter in `GET /price` and `POST /quotes`, and require `total_price` and `fee` in the responses of these endpoints. ([#86](https://github.com/stellar/stellar-anchor-tests/pull/86))
+- Update SEP-38 tests based on [stellar/stellar-protocol#1204](https://github.com/stellar/stellar-protocol/pull/1204). The changes include:
+  - SEP-38 `GET /price` and `POST /quote` now require the mandatory `context` request parameter.
+  - SEP-38 `GET /price` and `GET|POST /quote` now return the mandatory response parameters `total_price` and `fee`.
+  - The SEP-38 amounts formula validation was updated based on the new version from [SEP38#price-formulas](https://github.com/stellar/stellar-protocol/blob/faa99165050dcd44a9e0f700c3d019258d8b4321/ecosystem/sep-0038.md#price-formulas).
 
 ## [v0.4.1](https://github.com/stellar/stellar-anchor-tests/compare/v0.4.0...v0.4.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog documents all releases and included changes to the @stellar/ancho
 
 A breaking change will get clearly marked in this log.
 
+## [v0.5.0](https://github.com/stellar/stellar-anchor-tests/compare/v0.4.1...v0.5.0)
+
+### Update
+
+- SEP-38 tests now use the `context` parameter in `GET /price` and `POST /quotes`, and require `total_price` and `fee` in the responses of these endpoints. ([#86](https://github.com/stellar/stellar-anchor-tests/pull/86))
+
 ## [v0.4.1](https://github.com/stellar/stellar-anchor-tests/compare/v0.4.0...v0.4.1)
 
 ### Update

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@types/node": "^14.14.41",
-    "@stellar/anchor-tests": "0.4.1",
+    "@stellar/anchor-tests": "0.5.0",
     "express": "^4.17.1",
     "socket.io": "^4.1.2",
     "tslib": "^2.2.0",


### PR DESCRIPTION
### What

Update SEP-38 tests based on stellar/stellar-protocol#1204. The changes include:
* SEP-38 `GET /price` and `POST /quote` now require the mandatory `context` request parameter.
* SEP-38 `GET /price` and `GET|POST /quote` now return the mandatory response parameters `total_price` and `fee`.
* The updated formulas from [SEP38#price-formulas](https://github.com/stellar/stellar-protocol/blob/faa99165050dcd44a9e0f700c3d019258d8b4321/ecosystem/sep-0038.md#price-formulas) are now being validated.