### PR TITLE
add network calls for SEP-12 test

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep12/putCustomer.ts
+++ b/@stellar/anchor-tests/src/tests/sep12/putCustomer.ts
@@ -307,6 +307,7 @@ export const differentMemosSameAccount: Test = {
     const sendingCustomerCall: NetworkCall = {
       request: sep12Request,
     };
+    result.networkCalls.push(sendingCustomerCall);
     const sendingCustomerResponse = await makeRequest(
       sendingCustomerCall,
       202,
@@ -338,6 +339,7 @@ export const differentMemosSameAccount: Test = {
     const receivingCustomerCall: NetworkCall = {
       request: receivingCustomerRequest,
     };
+    result.networkCalls.push(receivingCustomerCall);
     const receivingCustomerResponse = await makeRequest(
       receivingCustomerCall,
       202,


### PR DESCRIPTION
We weren't adding the SEP-12 `PUT /customer` requests to the test result, so when the test failed, users couldn't see the requests that failed.