### PR TITLE
add network calls to result again

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep12/deleteCustomer.ts
+++ b/@stellar/anchor-tests/src/tests/sep12/deleteCustomer.ts
@@ -101,6 +101,7 @@ const canDeleteCustomer: Test = {
       result,
       "application/json",
     );
+    result.networkCalls.push(putCustomerCall);
     if (!putCustomerBody) return result;
     const getCustomerCall: NetworkCall = {
       request: new Request(
@@ -113,6 +114,7 @@ const canDeleteCustomer: Test = {
         },
       ),
     };
+    result.networkCalls.push(getCustomerCall);
     await makeRequest(getCustomerCall, 200, result);
     if (result.failure) return result;
     const deleteCustomerCall: NetworkCall = {
@@ -127,6 +129,7 @@ const canDeleteCustomer: Test = {
         },
       ),
     };
+    result.networkCalls.push(deleteCustomerCall);
     await makeRequest(deleteCustomerCall, 200, result);
     return result;
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ This changelog documents all releases and included changes to the @stellar/ancho
 
 A breaking change will get clearly marked in this log.
 
+## [v0.5.4](https://github.com/stellar/stellar-anchor-tests/compare/v0.5.3...v0.5.4)
+
+### Update
+
+- Add network calls to the test results for the following tests
+  - SEP-12: can delete a customer
+
+## [v0.5.3](https://github.com/stellar/stellar-anchor-tests/compare/v0.5.2...v0.5.3)
+
+### Update
+
+- Add network calls to the test results for the following tests
+  - SEP-12: memos differentiate customers registered by the same account
+
+## [v0.5.2](https://github.com/stellar/stellar-anchor-tests/compare/v0.5.1...v0.5.2)
+
+### Update
+
+- Use the account configured as the SEP-31 sending anchor when authenticating for the following test, if specified
+  - SEP-10: returns a valid JWT
+
 ## [v0.5.1](https://github.com/stellar/stellar-anchor-tests/compare/v0.5.0...v0.5.1)
 
 ### Update


### PR DESCRIPTION
Found another test that didn't add its requests to the test result.