### PR TITLE
Fix: when deleting a user, send the customer type if available in the json

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog documents all releases and included changes to the @stellar/ancho
 
 A breaking change will get clearly marked in this log.
 
+## [v0.5.5](https://github.com/stellar/stellar-anchor-tests/compare/v0.5.4...v0.5.5)
+
+### Fix
+
+- When deleting a user, send the customer type if available in the json body ([#101](https://github.com/stellar/stellar-anchor-tests/pull/101)).
+
 ## [v0.5.4](https://github.com/stellar/stellar-anchor-tests/compare/v0.5.3...v0.5.4)
 
 ### Update

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@types/node": "^14.14.41",
-    "@stellar/anchor-tests": "0.5.2",
+    "@stellar/anchor-tests": "0.5.5",
     "express": "^4.17.1",
     "socket.io": "^4.1.2",
     "tslib": "^2.2.0",


### PR DESCRIPTION
### What

When deleting a user, send the customer `type` if available in the customerToBeDeleted JSON.

### Why

To be compliant with SEP-12, where it says:

```text
Therefore it is recommended to always pass the `type` parameter when making requests to `GET /customer` or `PUT /customer`, even though the field is optional to accommodate for implementations that do not require type.
```

Some partners implementations require the type to be not empty, based on the statement above.
