### PR TITLE
Relax SEP-24 transaction schema

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep24.ts
+++ b/@stellar/anchor-tests/src/schemas/sep24.ts
@@ -113,12 +113,7 @@ export const transactionSchema = {
         "kind",
         "status",
         "more_info_url",
-        "amount_in",
-        "amount_out",
-        "amount_fee",
         "started_at",
-        "completed_at",
-        "stellar_transaction_id",
         "refunded",
       ],
     },
@@ -144,14 +139,8 @@ export const transactionsSchema = {
 
 export function getTransactionSchema(isDeposit: boolean) {
   const schema = JSON.parse(JSON.stringify(transactionSchema));
-  const requiredDepositParams = ["from", "to"];
-  const requiredWithdrawParams = [
-    "from",
-    "to",
-    "withdraw_memo",
-    "withdraw_memo_type",
-    "withdraw_anchor_account",
-  ];
+  const requiredDepositParams = ["to"];
+  const requiredWithdrawParams = ["from"];
 
   const depositProperties = {
     deposit_memo: {
@@ -187,14 +176,12 @@ export function getTransactionSchema(isDeposit: boolean) {
   };
 
   if (isDeposit) {
-    schema.properties.transaction.required = schema.properties.transaction.required.concat(
-      requiredDepositParams,
-    );
+    schema.properties.transaction.required =
+      schema.properties.transaction.required.concat(requiredDepositParams);
     Object.assign(schema.properties.transaction.properties, depositProperties);
   } else {
-    schema.properties.transaction.required = schema.properties.transaction.required.concat(
-      requiredWithdrawParams,
-    );
+    schema.properties.transaction.required =
+      schema.properties.transaction.required.concat(requiredWithdrawParams);
     Object.assign(schema.properties.transaction.properties, withdrawProperties);
   }
 


### PR DESCRIPTION
Relaxed SEP-24 transaction schema, as when transaction in incomplete status lots of required fields are not, in fact, required.