### PR TITLE
bump @stellar/anchor-tests to 0.5.8

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Makes a patch-version bump to 0.5.8 for `@stellar/anchor-tests` package.