### PR TITLE
Check to make sure testRun exists

### DIFF
--- a/ui/src/views/TestRunner.tsx
+++ b/ui/src/views/TestRunner.tsx
@@ -156,15 +156,17 @@ export const TestRunner = () => {
       const sepArray = testRunArrayCopy.find(({ sep }) => sep === test.sep);
       if (sepArray) {
         const testRun = sepArray.tests[testRunOrderMap[getTestRunId(test)]];
-        if (result) {
-          if (result.failureMode) {
-            sepArray.progress.failed++;
-          } else {
-            sepArray.progress.passed++;
+        if (testRun) {
+          if (result) {
+            if (result.failureMode) {
+              sepArray.progress.failed++;
+            } else {
+              sepArray.progress.passed++;
+            }
+            numberOfTestsRun.current++;
           }
-          numberOfTestsRun.current++;
+          testRun.result = result;
         }
-        testRun.result = result;
       }
       setTestRunArray(testRunArrayCopy);
 


### PR DESCRIPTION
This check will not break the flow if `testRun` does not exist in cases where we filter out a certain group of tests. For example, 
"Account Signer Support" in SEP-10 on mainnet [here](https://github.com/stellar/stellar-anchor-tests/blob/master/%40stellar/anchor-tests/src/helpers/test.ts#L328:L334).