### PR TITLE
[ANCHOR-305] Update tests to support stellar:native asset

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep1.ts
+++ b/@stellar/anchor-tests/src/schemas/sep1.ts
@@ -40,7 +40,6 @@ export const currencySchema = {
     "is_asset_anchored",
     "anchor_asset_type",
     "code",
-    "issuer",
     "desc",
     "status",
   ],

--- a/@stellar/anchor-tests/src/tests/sep38/info.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/info.ts
@@ -104,7 +104,7 @@ export const hasValidInfoSchema: Test = {
         const failure = makeFailure(this.failureModes.INVALID_ASSET_VALUE, {
           asset: asset.asset,
         });
-        if (parts.length !== 3) {
+        if (parts.length !== 3 && asset !== "stellar:native") {
           result.failure = failure;
           return result;
         }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ See each project for more information. To install and run all applications:
 ```sh
 git clone git@github.com:stellar/stellar-anchor-tests.git
 cd stellar-anchor-tests
+yarn install
 yarn build:all
 yarn start:all
 ```

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.5.8"
+    "@stellar/anchor-tests": "0.5.9"
   }
 }


### PR DESCRIPTION
When an anchor supports the native asset, it will add the following configurations. These are currently considered invalid by the tests.

#### `stellar.toml`
```
[[CURRENCIES]]
code = "native"
status = "test"
is_asset_anchored = false
anchor_asset_type = "crypto"
desc = "XLM, the native token of the Stellar network."
```
This is not valid because `issuer` is required. However, `issuer` is not applicable for the native asset and can be excluded per [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md#currency-documentation).

#### `assets.yaml`
```
 - schema: stellar
    code: native
    distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
    significant_decimals: 7
    deposit:
      enabled: true
      max_amount: 1000000
    withdraw:
      enabled: true
      max_amount: 1000000
    send:
      fee_fixed: 0
      fee_percent: 0
      max_amount: 1000000
```
This is not valid because `issuer` is required. However, `stellar:native` is a valid in the SEP-38 asset identification format.