### PR TITLE
Fix stellar:native asset SEP-38 info validation

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep38/info.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/info.ts
@@ -104,12 +104,14 @@ export const hasValidInfoSchema: Test = {
         const failure = makeFailure(this.failureModes.INVALID_ASSET_VALUE, {
           asset: asset.asset,
         });
-        if (parts.length !== 3 && asset !== "stellar:native") {
+        if (parts.length !== 3 && asset.asset !== "stellar:native") {
           result.failure = failure;
           return result;
         }
         try {
-          Keypair.fromPublicKey(parts[2]);
+          if (asset.asset !== "stellar:native") {
+            Keypair.fromPublicKey(parts[2]);
+          }
         } catch {
           result.failure = failure;
           return result;

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.5.9"
+    "@stellar/anchor-tests": "0.5.10"
   }
 }


### PR DESCRIPTION
We should be checking `asset.asset !== "stellar:native"` not `asset !== "stellar:native:`

```
❯ yarn stellar-anchor-tests --seps 38 --home-domain http://localhost:8080 --sep-config /Users/philipliu/Documents/work/java-stellar-anchor-sdk/platform/src/test/resources/stellar-anchor-tests-sep-config.json
yarn run v1.22.19
$ node @stellar/anchor-tests/lib/cli.js --seps 38 --home-domain http://localhost:8080 --sep-config /Users/philipliu/Documents/work/java-stellar-anchor-sdk/platform/src/test/resources/stellar-anchor-tests-sep-config.json
✔ SEP-1 › TOML Tests › the TOML file exists at ./well-known/stellar.toml
✔ SEP-38 › TOML Tests › has an ANCHOR_QUOTE_SERVER attribute
failed to read keypair
failed to read keypair
✔ SEP-38 › GET /info › returns a valid info response
✔ SEP-10 › TOML Tests › has a valid WEB_AUTH_ENDPOINT in the TOML file
✔ SEP-10 › POST /auth › returns a valid JWT
✔ SEP-38 › GET /prices › returns a valid response
✔ SEP-38 › GET /prices › allows off-chain assets as 'sell_asset'
✔ SEP-38 › GET /prices › specifying delivery method is optional
✔ SEP-38 › GET /price › returns a valid response with
✔ SEP-38 › GET /price › returned amounts are calculated correctly
✔ SEP-38 › GET /price › accepts the 'buy_amount' parameter with
✔ SEP-38 › GET /price › specifying delivery method is optional with
✔ SEP-38 › POST /quote › requires SEP-10 authentication
✔ SEP-38 › POST /quote › returns a valid response
✔ SEP-38 › POST /quote › quote amounts are correctly calculated
✔ SEP-38 › GET /quote › requires SEP-10 authentication
✔ SEP-38 › GET /quote › can fetch an existing quote
✔ SEP-38 › GET /quote › returns a 404 for unknown quote IDs

Tests:       18 passed, 18 total
Time:        1.571s
✨  Done in 1.92s.
```