### PR TITLE
Fix false-positive for withdraw tx schema validation on /transaction

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep24/transaction.ts
+++ b/@stellar/anchor-tests/src/tests/sep24/transaction.ts
@@ -204,7 +204,7 @@ export const hasProperWithdrawTransactionSchema: Test = {
   async run(_config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
     const validationResult = validate(
-      this.context.expects.depositTransactionObj,
+      this.context.expects.withdrawTransactionObj,
       getTransactionSchema(false),
     );
     if (validationResult.errors.length !== 0) {

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.5.10"
+    "@stellar/anchor-tests": "0.5.11"
   }
 }


### PR DESCRIPTION
This PR fixes a bug on the following test: `has proper withdraw transaction schema on /transaction`

It turns out that the validation of this withdraw transaction schema test was actually pointing to the `depositTransactionObj` instead of `withdrawTransactionObj` which was giving `false-positives`.

However, we also have similar test for `/transactions` endpoint (`has proper withdraw transaction schema on /transactions`) which is pointing to the correct `withdrawTransactionsObj` on its validation which appears to cover for the `/transaction` bug down the testing stack so Anchors would know at this point if there was any schema issues with withdraw transaction.

## Sample of the issue
![Screenshot 2023-06-16 at 18 46 33](https://github.com/stellar/stellar-anchor-tests/assets/3228151/0fc01438-e384-4c24-a70b-ce269e6c53fa)
