### PR TITLE
Release v0.5.12

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This changelog documents all releases and included changes to the @stellar/ancho
 
 A breaking change will get clearly marked in this log.
 
+## [v0.5.12](https://github.com/stellar/stellar-anchor-tests/compare/v0.5.5...v0.5.12)
+- Add Dockerfile, build and push docker images to hub.docker.io
+
 ## [v0.5.6](https://github.com/stellar/stellar-anchor-tests/compare/v0.5.5...v0.5.6)
 
 ### Update

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.5.11"
+    "@stellar/anchor-tests": "0.5.12"
   }
 }


### PR DESCRIPTION
Create release v0.5.12 to build and push the docker image to `hub.docker.com`