### PR TITLE
Bypass HTTPS checks with when the hostname is host.docker.internal

### DIFF
--- a/@stellar/anchor-tests/src/tests/sep1/tests.ts
+++ b/@stellar/anchor-tests/src/tests/sep1/tests.ts
@@ -339,7 +339,10 @@ const validUrls: Test = {
       if (!u) return;
       if (
         !u.startsWith("https://") &&
-        !config.homeDomain.includes("localhost")
+        !(
+          config.homeDomain.includes("localhost") ||
+          config.homeDomain.includes("host.docker.internal")
+        )
       ) {
         result.failure = makeFailure(this.failureModes.NO_HTTPS);
       } else if (u.slice(-1) === "/") {

--- a/@stellar/anchor-tests/src/tests/sep10/tests.ts
+++ b/@stellar/anchor-tests/src/tests/sep10/tests.ts
@@ -77,7 +77,10 @@ export const hasWebAuthEndpoint: Test = {
     }
     if (
       !this.context.expects.tomlObj.WEB_AUTH_ENDPOINT.startsWith("https") &&
-      !config.homeDomain.includes("localhost")
+      !(
+        config.homeDomain.includes("localhost") ||
+        config.homeDomain.includes("host.docker.internal")
+      )
     ) {
       result.failure = makeFailure(this.failureModes.NO_HTTPS);
       return result;

--- a/@stellar/anchor-tests/src/tests/sep12/toml.ts
+++ b/@stellar/anchor-tests/src/tests/sep12/toml.ts
@@ -49,7 +49,10 @@ export const hasKycServerUrl: Test = {
     }
     if (
       !this.context.provides.kycServerUrl.startsWith("https") &&
-      !config.homeDomain.includes("localhost")
+      !(
+        config.homeDomain.includes("localhost") ||
+        config.homeDomain.includes("host.docker.internal")
+      )
     ) {
       result.failure = makeFailure(this.failureModes.NO_HTTPS);
       return result;

--- a/@stellar/anchor-tests/src/tests/sep24/toml.ts
+++ b/@stellar/anchor-tests/src/tests/sep24/toml.ts
@@ -52,7 +52,10 @@ export const hasTransferServerUrl: Test = {
     }
     if (
       !this.context.provides.transferServerUrl.startsWith("https") &&
-      !config.homeDomain.includes("localhost")
+      !(
+        config.homeDomain.includes("localhost") ||
+        config.homeDomain.includes("host.docker.internal")
+      )
     ) {
       result.failure = makeFailure(this.failureModes.NO_HTTPS);
       return result;

--- a/@stellar/anchor-tests/src/tests/sep31/toml.ts
+++ b/@stellar/anchor-tests/src/tests/sep31/toml.ts
@@ -51,7 +51,10 @@ export const hasDirectPaymentServer: Test = {
     }
     if (
       !this.context.provides.directPaymentServerUrl.startsWith("https") &&
-      !config.homeDomain.includes("localhost")
+      !(
+        config.homeDomain.includes("localhost") ||
+        config.homeDomain.includes("host.docker.internal")
+      )
     ) {
       result.failure = makeFailure(this.failureModes.NO_HTTPS);
       return result;

--- a/@stellar/anchor-tests/src/tests/sep38/toml.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/toml.ts
@@ -44,12 +44,17 @@ export const hasQuoteServer: Test = {
     this.context.provides.quoteServerUrl =
       this.context.expects.tomlObj.ANCHOR_QUOTE_SERVER;
     if (!this.context.provides.quoteServerUrl) {
-      result.failure = makeFailure(this.failureModes.ANCHOR_QUOTE_SERVER_NOT_FOUND);
+      result.failure = makeFailure(
+        this.failureModes.ANCHOR_QUOTE_SERVER_NOT_FOUND,
+      );
       return result;
     }
     if (
       !this.context.provides.quoteServerUrl.startsWith("https") &&
-      !config.homeDomain.includes("localhost")
+      !(
+        config.homeDomain.includes("localhost") ||
+        config.homeDomain.includes("host.docker.internal")
+      )
     ) {
       result.failure = makeFailure(this.failureModes.NO_HTTPS);
       return result;

--- a/@stellar/anchor-tests/src/tests/sep6/toml.ts
+++ b/@stellar/anchor-tests/src/tests/sep6/toml.ts
@@ -51,7 +51,10 @@ export const hasTransferServerUrl: Test = {
     }
     if (
       !this.context.provides.sep6TransferServerUrl.startsWith("https") &&
-      !config.homeDomain.includes("localhost")
+      !(
+        config.homeDomain.includes("localhost") ||
+        config.homeDomain.includes("host.docker.internal")
+      )
     ) {
       result.failure = makeFailure(this.failureModes.NO_HTTPS);
       return result;


### PR DESCRIPTION
When we run the tests from the docker container against the anchor in the host network, we will use `host.docker.internal` as the endpoint host. We need to bypass HTTPS checks for `host.docker.internal`.