### PR TITLE
[ANCHOR-353] SEP-6: Fix required transaction fields

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep6.ts
+++ b/@stellar/anchor-tests/src/schemas/sep6.ts
@@ -213,7 +213,7 @@ export const transactionSchema = {
         status: {
           type: "string",
           pattern:
-            "completed|pending_external|pending_anchor|pending_stellar|pending_trust|pending_user|pending_user_transfer_start|incomplete|no_market|too_small|too_large|error",
+            "completed|pending_external|pending_anchor|pending_stellar|pending_trust|pending_user|pending_customer_info_update|pending_user_transfer_start|incomplete|no_market|too_small|too_large|error",
         },
         more_info_url: {
           type: "string",
@@ -255,18 +255,7 @@ export const transactionSchema = {
           type: ["string", "null"],
         },
       },
-      required: [
-        "id",
-        "kind",
-        "status",
-        "amount_in",
-        "amount_out",
-        "amount_fee",
-        "started_at",
-        "completed_at",
-        "stellar_transaction_id",
-        "refunded",
-      ],
+      required: ["id", "kind", "status", "started_at"],
     },
   },
   required: ["transaction"],
@@ -290,10 +279,9 @@ export const transactionsSchema = {
 
 export function getTransactionSchema(isDeposit: boolean) {
   const schema = JSON.parse(JSON.stringify(transactionSchema));
-  const requiredDepositParams = ["from", "to"];
+  const requiredDepositParams = ["to"];
   const requiredWithdrawParams = [
     "from",
-    "to",
     "withdraw_memo",
     "withdraw_memo_type",
     "withdraw_anchor_account",
@@ -333,14 +321,12 @@ export function getTransactionSchema(isDeposit: boolean) {
   };
 
   if (isDeposit) {
-    schema.properties.transaction.required = schema.properties.transaction.required.concat(
-      requiredDepositParams,
-    );
+    schema.properties.transaction.required =
+      schema.properties.transaction.required.concat(requiredDepositParams);
     Object.assign(schema.properties.transaction.properties, depositProperties);
   } else {
-    schema.properties.transaction.required = schema.properties.transaction.required.concat(
-      requiredWithdrawParams,
-    );
+    schema.properties.transaction.required =
+      schema.properties.transaction.required.concat(requiredWithdrawParams);
     Object.assign(schema.properties.transaction.properties, withdrawProperties);
   }
 

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.0"
+    "@stellar/anchor-tests": "0.6.1"
   }
 }


### PR DESCRIPTION
Some of the required fields cannot be known at the time of deposit/withdraw transaction creation. It also adds a new possible status `PENDING_CUSTOMER_INFO_UPDATE` to SEP-6 transactions, as Anchors can now decide they require more KYC info before requesting user funds.