### PR TITLE
Fix: Make Dockerhub publish dependent on npm publish

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,7 +1,10 @@
 name: docker image publish
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["npm publish"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build_and_push_docker_image:


### PR DESCRIPTION
Currently, there is a race where the Dockerhub publish completes before the npm one does, causing the image to use the older version of the test package.

Reference: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run