### PR TITLE
[ANCHOR-487] Skip failing tests that needs anchor config

### DIFF
--- a/@stellar/anchor-tests/README.md
+++ b/@stellar/anchor-tests/README.md
@@ -27,6 +27,8 @@ Options:
                                                               [array] [required]
   -v, --verbose      Display the each request and response used in each failed
                      test.                            [boolean] [default: false]
+  --sep-config       Path to a JSON file containing SEP-specific configuration
+                     options. See below for config examples.                    [string]
 ```
 
 ```
@@ -58,4 +60,91 @@ const config: Config = {
     console.dir(testRun, { depth: Infinity });
   }
 })()
+```
+
+### SEP config example
+
+```json
+{
+  "12": {
+    "customers": {
+      "toBeCreated": {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email_address": "john@email.com",
+        "bank_number": "123",
+        "bank_account_number": "456",
+        "bank_account_type": "checking"
+      },
+      "sendingClient": {
+        "first_name": "Allie",
+        "last_name": "Grater",
+        "email_address": "allie@email.com"
+      },
+      "receivingClient": {
+        "first_name": "Lee",
+        "last_name": "Sun",
+        "email_address": "lee@email.com",
+        "clabe_number": "1234",
+        "bank_number": "abcd",
+        "bank_account_number": "1234",
+        "bank_account_type": "checking"
+      },
+      "toBeDeleted": {
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "email_address": "jane@email.com"
+      }
+    },
+    "createCustomer": "toBeCreated",
+    "deleteCustomer": "toBeDeleted",
+    "sameAccountDifferentMemos": ["sendingClient", "receivingClient"]
+  },
+  /*
+   * SEP-24 config is optional for enabling partial tests in transaction. 
+   * Please provide valid input if you plan to do so.
+   */
+  "24": {
+    "account": {
+      "publicKey": "<your_public_key>",
+      "secretKey": "<your_secret_key>"
+    },
+    "depositPendingTransaction": {
+      "id": "<id>",
+      "status": "any pending_ status"
+    },
+    "depositCompletedTransaction": {
+      "id": "<id>",
+      "status": "completed",
+      "stellar_transaction_id": "<valid_completed_deposit_transaction_id>"
+    },
+    "withdrawPendingUserTransferStartTransaction": {
+      "id": "<id>",
+      "status": "pending_user_transfer_start",
+      "amount_in": "222.00",
+      "amount_in_asset": "",
+      "withdraw_anchor_account": "",
+      "withdraw_memo": "<id>",
+      "withdraw_memo_type": "text"
+    },
+    "withdrawCompletedTransaction": {
+      "id": "<id>",
+      "status": "completed",
+      "stellar_transaction_id": "<valid_completed_withdraw_transaction_id>"
+    }
+  },
+  "31": {
+    "sendingAnchorClientSecret": "<secret>",
+    "sendingClientName": "sendingClient",
+    "receivingClientName": "receivingClient",
+    "transactionFields": {
+      "receiver_account_number": "123",
+      "receiver_routing_number": "456",
+      "type": "SWIFT"
+    }
+  },
+  "38": {
+    "contexts": ["sep31"]
+  }
+}
 ```

--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep24/transaction.ts
+++ b/@stellar/anchor-tests/src/tests/sep24/transaction.ts
@@ -191,10 +191,9 @@ const hasProperPendingDepositTransactionSchema: Test = {
   async run(config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
 
-    if (!config.sepConfig?.["24"]) {
-      result.failure = makeFailure(this.failureModes.MISSING_CONFIG, {
-        sep: "SEP-24",
-      });
+    // Skip this test if SEP-24 config with field depositPendingTransaction is not present
+    if (!config.sepConfig?.["24"]?.depositPendingTransaction) {
+      result.skipped = true;
       return result;
     }
 
@@ -273,10 +272,9 @@ const hasProperCompletedDepositTransactionSchema: Test = {
   async run(config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
 
-    if (!config.sepConfig?.["24"]) {
-      result.failure = makeFailure(this.failureModes.MISSING_CONFIG, {
-        sep: "SEP-24",
-      });
+    // Skip this test if SEP-24 config with field depositCompletedTransaction is not present
+    if (!config.sepConfig?.["24"]?.depositCompletedTransaction) {
+      result.skipped = true;
       return result;
     }
 
@@ -403,10 +401,11 @@ export const hasProperPendingWithdrawTransactionSchema: Test = {
   async run(config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
 
-    if (!config.sepConfig?.["24"]) {
-      result.failure = makeFailure(this.failureModes.MISSING_CONFIG, {
-        sep: "SEP-24",
-      });
+    // Skip this test if SEP-24 config with field withdrawPendingUserTransferStartTransaction is not present
+    if (
+      !config.sepConfig?.["24"]?.withdrawPendingUserTransferStartTransaction
+    ) {
+      result.skipped = true;
       return result;
     }
 
@@ -485,10 +484,9 @@ export const hasProperCompletedWithdrawTransactionSchema: Test = {
   async run(config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
 
-    if (!config.sepConfig?.["24"]) {
-      result.failure = makeFailure(this.failureModes.MISSING_CONFIG, {
-        sep: "SEP-24",
-      });
+    // Skip this test if SEP-24 config with field withdrawCompletedTransaction is not present
+    if (!config.sepConfig?.["24"]?.withdrawCompletedTransaction) {
+      result.skipped = true;
       return result;
     }
 
@@ -562,10 +560,9 @@ const returnsDepositTransactionForStellarTxId: Test = {
   async run(config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
 
-    if (!config.sepConfig?.["24"]) {
-      result.failure = makeFailure(this.failureModes.MISSING_CONFIG, {
-        sep: "SEP-24",
-      });
+    // Skip this test if SEP-24 config with field depositCompletedTransaction is not present
+    if (!config.sepConfig?.["24"]?.depositCompletedTransaction) {
+      result.skipped = true;
       return result;
     }
 
@@ -631,10 +628,9 @@ const returnsWithdrawTransactionForStellarTxId: Test = {
   async run(config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
 
-    if (!config.sepConfig?.["24"]) {
-      result.failure = makeFailure(this.failureModes.MISSING_CONFIG, {
-        sep: "SEP-24",
-      });
+    // Skip this test if SEP-24 config with field depositCompletedTransaction is not present
+    if (!config.sepConfig?.["24"]?.withdrawCompletedTransaction) {
+      result.skipped = true;
       return result;
     }
 


### PR DESCRIPTION
**Description**

Disable the tests added in [PR117](https://github.com/stellar/stellar-anchor-tests/pull/117) , which are constantly failing without SEP-24 config

 **Context**
> In order to fulfill those tests Anchors will need to upload a config file in schema format with credentials and info related to existing pending and completed transactions.

For details please refer to the discussion in original PR

These PR change it to skip these tests (instead of failing) if config is not present  

**Test**
Run `yarn build:anchor-tests && yarn stellar-anchor-tests --home-domain http://localhost:8080 --seps 24 --sep-config $SEP_CONFIG`
<img width="880" alt="Screenshot 2023-10-12 at 3 29 09 PM" src="https://github.com/stellar/stellar-anchor-tests/assets/16715182/e27e5df4-4cc5-42a0-b276-2ec352e223e6">
