### PR TITLE
Fix `docke_publish` is not triggered by `workflow_run` action

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,10 +1,7 @@
 name: docker image publish
 on:
-  workflow_run:
-    workflows: ["npm publish"]
-    branches: [master]
-    types:
-      - completed
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   build_and_push_docker_image:

--- a/.github/workflows/npm_and_docker_publish.yml
+++ b/.github/workflows/npm_and_docker_publish.yml
@@ -1,4 +1,4 @@
-name: npm publish
+name: npm and docker publish
 on:
   release:
     types: [published]
@@ -26,3 +26,6 @@ jobs:
         run: yarn publish:anchor-tests
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish docker image
+        uses: ./.github/workflows/docker_publish.yml

--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Right now docker publish is not triggered by dependency `npm_publish` `completed`.
Change it to be manually invoked in `npm_publish`