### PR TITLE
[ANCHOR-515] SEP-6: Remove KYC verification

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep6.ts
+++ b/@stellar/anchor-tests/src/schemas/sep6.ts
@@ -1,5 +1,3 @@
-import { sep9Fields } from "./sep12";
-
 const fieldsSchema = {
   type: "object",
   additionalProperties: {
@@ -88,23 +86,6 @@ export const infoSchema = {
     transactions: otherFieldSchema,
   },
   required: ["deposit", "withdraw", "fee", "transaction", "transactions"],
-};
-
-export const needsInfoResponseSchema = {
-  type: "object",
-  properties: {
-    type: {
-      type: "string",
-      pattern: "non_interactive_customer_info_needed",
-    },
-    fields: {
-      type: "array",
-      items: {
-        type: "string",
-        enum: sep9Fields,
-      },
-    },
-  },
 };
 
 export const customerInfoStatusSchema = {

--- a/@stellar/anchor-tests/src/tests/sep6/deposit.ts
+++ b/@stellar/anchor-tests/src/tests/sep6/deposit.ts
@@ -5,14 +5,12 @@ import { validate } from "jsonschema";
 
 import { Test, Config, Result, NetworkCall } from "../../types";
 import { makeRequest } from "../../helpers/request";
-import { postChallenge } from "../../helpers/sep10";
 import { genericFailures, makeFailure } from "../../helpers/failure";
 import { hasWebAuthEndpoint, returnsValidJwt } from "../sep10/tests";
 import { canCreateCustomer } from "../sep12/putCustomer";
 import { hasTransferServerUrl } from "./toml";
 import { assetCodeEnabledForDeposit, isCompliantWithSchema } from "./info";
 import {
-  needsInfoResponseSchema,
   depositSuccessResponseSchema,
   customerInfoStatusSchema,
 } from "../../schemas/sep6";
@@ -288,87 +286,6 @@ const depositRejectsUnsupportedAssetCode: Test = {
   },
 };
 tests.push(depositRejectsUnsupportedAssetCode);
-
-export const returnsProperSchemaForUnknownAccounts: Test = {
-  assertion:
-    "returns a needs info response for valid requests from unknown accounts",
-  sep: 6,
-  group: depositTestsGroup,
-  dependencies: depositRequiresAssetCode.dependencies,
-  context: {
-    expects: depositRequiresAssetCode.context.expects,
-    provides: {
-      sep6FieldsRequired: undefined,
-    },
-  },
-  failureModes: {
-    INVALID_SCHEMA: {
-      name: "invalid schema",
-      text(args: any): string {
-        return (
-          "The response body returned does not comply with the schema defined for the /deposit endpoint. " +
-          "The errors returned from the schema validation:\n\n" +
-          `${args.errors}`
-        );
-      },
-      links: {
-        "Deposit Response":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#2-customer-information-needed-non-interactive",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(config: Config): Promise<Result> {
-    if (!config.sepConfig || !config.sepConfig["6"])
-      throw { message: "improperly configured" };
-    const result: Result = { networkCalls: [] };
-    const clientKeypair = Keypair.random();
-    const token = await postChallenge(
-      clientKeypair,
-      this.context.expects.webAuthEndpoint,
-      this.context.expects.tomlObj.NETWORK_PASSPHRASE,
-      result,
-    );
-    const headers = this.context.expects.authRequired
-      ? {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      : {};
-    const callParams = new URLSearchParams({
-      asset_code: config.assetCode,
-      account: clientKeypair.publicKey(),
-      ...config.sepConfig["6"].deposit.transactionFields,
-    });
-    const getDepositCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.sep6TransferServerUrl +
-          depositEndpoint +
-          `?${callParams.toString()}`,
-        { ...headers },
-      ),
-    };
-    result.networkCalls.push(getDepositCall);
-    const responseBody = await makeRequest(
-      getDepositCall,
-      403,
-      result,
-      "application/json",
-    );
-    if (!responseBody) return result;
-    const validatorResult = validate(responseBody, needsInfoResponseSchema);
-    if (validatorResult.errors.length !== 0) {
-      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
-        errors: validatorResult.errors.join("\n"),
-      });
-      return result;
-    }
-    this.context.provides.sep6FieldsRequired = responseBody.fields;
-    return result;
-  },
-};
-tests.push(returnsProperSchemaForUnknownAccounts);
 
 export const returnsProperSchemaForKnownAccounts: Test = {
   assertion:

--- a/@stellar/anchor-tests/src/tests/sep6/deposit.ts
+++ b/@stellar/anchor-tests/src/tests/sep6/deposit.ts
@@ -7,7 +7,6 @@ import { Test, Config, Result, NetworkCall } from "../../types";
 import { makeRequest } from "../../helpers/request";
 import { genericFailures, makeFailure } from "../../helpers/failure";
 import { hasWebAuthEndpoint, returnsValidJwt } from "../sep10/tests";
-import { canCreateCustomer } from "../sep12/putCustomer";
 import { hasTransferServerUrl } from "./toml";
 import { assetCodeEnabledForDeposit, isCompliantWithSchema } from "./info";
 import {
@@ -288,12 +287,11 @@ const depositRejectsUnsupportedAssetCode: Test = {
 tests.push(depositRejectsUnsupportedAssetCode);
 
 export const returnsProperSchemaForKnownAccounts: Test = {
-  assertion:
-    "returns a success or customer info status response for valid requests from KYC'ed accounts",
+  assertion: "returns a success response for valid requests",
   sep: 6,
   group: depositTestsGroup,
   dependencies: (config: Config) => {
-    let resultDependencies = [canCreateCustomer];
+    let resultDependencies: Test[] = [];
 
     if (depositRequiresAssetCode.dependencies) {
       let otherDependencies =

--- a/@stellar/anchor-tests/src/tests/sep6/withdraw.ts
+++ b/@stellar/anchor-tests/src/tests/sep6/withdraw.ts
@@ -5,14 +5,12 @@ import { validate } from "jsonschema";
 
 import { Test, Config, Result, NetworkCall } from "../../types";
 import { makeRequest } from "../../helpers/request";
-import { postChallenge } from "../../helpers/sep10";
 import { genericFailures, makeFailure } from "../../helpers/failure";
 import { hasWebAuthEndpoint, returnsValidJwt } from "../sep10/tests";
 import { canCreateCustomer } from "../sep12/putCustomer";
 import { hasTransferServerUrl } from "./toml";
 import { assetCodeEnabledForWithdraw, isCompliantWithSchema } from "./info";
 import {
-  needsInfoResponseSchema,
   withdrawSuccessResponseSchema,
   customerInfoStatusSchema,
 } from "../../schemas/sep6";
@@ -334,99 +332,6 @@ const withdrawRejectsUnsupportedAssetCode: Test = {
   },
 };
 tests.push(withdrawRejectsUnsupportedAssetCode);
-
-export const returnsProperSchemaForUnknownAccounts: Test = {
-  assertion:
-    "returns a needs info response for valid requests from unknown accounts",
-  sep: 6,
-  group: withdrawTestsGroup,
-  dependencies: withdrawRequiresAssetCode.dependencies,
-  context: {
-    expects: withdrawRequiresAssetCode.context.expects,
-    provides: {
-      sep6FieldsRequired: undefined,
-    },
-  },
-  failureModes: {
-    INVALID_SCHEMA: {
-      name: "invalid schema",
-      text(args: any): string {
-        return (
-          "The response body returned does not comply with the schema defined for the /withdraw endpoint. " +
-          "The errors returned from the schema validation:\n\n" +
-          `${args.errors}`
-        );
-      },
-      links: {
-        "Withdraw Schema":
-          "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#2-customer-information-needed-non-interactive",
-      },
-    },
-    ...genericFailures,
-  },
-  async run(config: Config): Promise<Result> {
-    if (
-      !config.sepConfig ||
-      !config.sepConfig["6"] ||
-      !config.assetCode ||
-      !config.sepConfig["6"].withdraw.types
-    )
-      throw { message: "improperly configured" };
-    const result: Result = { networkCalls: [] };
-    const clientKeypair = Keypair.random();
-    const token = await postChallenge(
-      clientKeypair,
-      this.context.expects.webAuthEndpoint,
-      this.context.expects.tomlObj.NETWORK_PASSPHRASE,
-      result,
-    );
-    const headers = this.context.expects.authRequired
-      ? {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      : {};
-    const withdrawInfo =
-      this.context.expects.sep6InfoObj.withdraw[config.assetCode];
-    const withdrawType = Object.keys(withdrawInfo.types)[0];
-    const withdrawTypeFields =
-      config.sepConfig["6"].withdraw.types[withdrawType].transactionFields ||
-      {};
-    const callParams = new URLSearchParams({
-      asset_code: config.assetCode,
-      account: clientKeypair.publicKey(),
-      type: withdrawType,
-      ...withdrawTypeFields,
-    });
-    const getWithdrawCall: NetworkCall = {
-      request: new Request(
-        this.context.expects.sep6TransferServerUrl +
-          withdrawEndpoint +
-          `?${callParams.toString()}`,
-        { ...headers },
-      ),
-    };
-    result.networkCalls.push(getWithdrawCall);
-    const responseBody = await makeRequest(
-      getWithdrawCall,
-      403,
-      result,
-      "application/json",
-    );
-    if (!responseBody) return result;
-    const validatorResult = validate(responseBody, needsInfoResponseSchema);
-    if (validatorResult.errors.length !== 0) {
-      result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
-        errors: validatorResult.errors.join("\n"),
-      });
-      return result;
-    }
-    this.context.provides.sep6FieldsRequired = responseBody.fields;
-    return result;
-  },
-};
-tests.push(returnsProperSchemaForUnknownAccounts);
 
 export const returnsProperSchemaForKnownAccounts: Test = {
   assertion:

--- a/@stellar/anchor-tests/src/tests/sep6/withdraw.ts
+++ b/@stellar/anchor-tests/src/tests/sep6/withdraw.ts
@@ -7,7 +7,6 @@ import { Test, Config, Result, NetworkCall } from "../../types";
 import { makeRequest } from "../../helpers/request";
 import { genericFailures, makeFailure } from "../../helpers/failure";
 import { hasWebAuthEndpoint, returnsValidJwt } from "../sep10/tests";
-import { canCreateCustomer } from "../sep12/putCustomer";
 import { hasTransferServerUrl } from "./toml";
 import { assetCodeEnabledForWithdraw, isCompliantWithSchema } from "./info";
 import {
@@ -334,12 +333,11 @@ const withdrawRejectsUnsupportedAssetCode: Test = {
 tests.push(withdrawRejectsUnsupportedAssetCode);
 
 export const returnsProperSchemaForKnownAccounts: Test = {
-  assertion:
-    "returns a success or customer info status response for valid requests from KYC'ed accounts",
+  assertion: "returns a success response for valid requests",
   sep: 6,
   group: withdrawTestsGroup,
   dependencies: (config: Config) => {
-    let resultDependencies = [canCreateCustomer];
+    let resultDependencies: Test[] = [];
 
     if (withdrawRequiresAssetCode.dependencies) {
       let otherDependencies =

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.6"
+    "@stellar/anchor-tests": "0.6.7"
   }
 }


### PR DESCRIPTION
Anchor Platform accepts KYC asynchronously so it does not do any KYC verification before a transaction is created. This PR removes the associated tests.