### PR TITLE
SEP-6: Support async withdrawal instructions

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep6.ts
+++ b/@stellar/anchor-tests/src/schemas/sep6.ts
@@ -261,12 +261,7 @@ export const transactionsSchema = {
 export function getTransactionSchema(isDeposit: boolean) {
   const schema = JSON.parse(JSON.stringify(transactionSchema));
   const requiredDepositParams = ["to"];
-  const requiredWithdrawParams = [
-    "from",
-    "withdraw_memo",
-    "withdraw_memo_type",
-    "withdraw_anchor_account",
-  ];
+  const requiredWithdrawParams = ["from"];
 
   const depositProperties = {
     deposit_memo: {

--- a/@stellar/anchor-tests/src/tests/sep6/withdraw.ts
+++ b/@stellar/anchor-tests/src/tests/sep6/withdraw.ts
@@ -446,7 +446,9 @@ export const returnsProperSchemaForKnownAccounts: Test = {
         memoValue = Buffer.from(responseBody.memo, "base64");
       }
       try {
-        new Memo(responseBody.memo_type, memoValue);
+        if (memoValue) {
+          new Memo(responseBody.memo_type, memoValue);
+        }
       } catch {
         result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
           errors: "invalid 'memo' for 'memo_type'",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.7"
+    "@stellar/anchor-tests": "0.6.8"
   }
 }


### PR DESCRIPTION
See the [protocol change](https://github.com/stellar/stellar-protocol/pull/1417) for motivation.

This makes the `withdraw_anchor_account`, `withdraw_memo`, and `withdraw_memo` optional in the GET /transaction response. It also fixes a bug that tries to validate a `memo` even if one is not provided in the withdrawal response.