### PR TITLE
[Fix] SEP-6: Make `account_id` optional in withdraw response

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep6.ts
+++ b/@stellar/anchor-tests/src/schemas/sep6.ts
@@ -179,7 +179,7 @@ export const withdrawSuccessResponseSchema = {
       type: "object",
     },
   },
-  required: ["account_id", "id"],
+  required: ["id"],
   additionalProperties: false,
 };
 

--- a/@stellar/anchor-tests/src/tests/sep6/withdraw.ts
+++ b/@stellar/anchor-tests/src/tests/sep6/withdraw.ts
@@ -434,7 +434,9 @@ export const returnsProperSchemaForKnownAccounts: Test = {
     this.context.provides.sep6WithdrawTransactionId = responseBody.id || null;
     if (getWithdrawCall.response.status === 200) {
       try {
-        Keypair.fromPublicKey(responseBody.account_id);
+        if (responseBody.account_id) {
+          Keypair.fromPublicKey(responseBody.account_id);
+        }
       } catch {
         result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
           errors: "invalid Stellar public key",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.8"
+    "@stellar/anchor-tests": "0.6.9"
   }
 }


### PR DESCRIPTION
The previous PR (https://github.com/stellar/stellar-anchor-tests/pull/132) did not make the `account_id` optional, which is omitted when the Anchor cannot provide the deposit address at transaction initiation.