### PR TITLE
SEP-12: Add missing SEP-9 fields

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep12.ts
+++ b/@stellar/anchor-tests/src/schemas/sep12.ts
@@ -40,6 +40,10 @@ export const sep9Fields = [
   "notary_approval_of_photo_id",
   "ip_address",
   "photo_proof_residence",
+  "sex",
+  "photo_proof_of_income",
+  "proof_of_liveness",
+  "referral_id",
   "type",
 ];
 

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.9"
+    "@stellar/anchor-tests": "0.6.10"
   }
 }


### PR DESCRIPTION
This commit adds the remaining SEP-9 fields to the SEP-12 schema validation test.