### PR TITLE
Make SEP-31 transfer fields optional

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep31.ts
+++ b/@stellar/anchor-tests/src/schemas/sep31.ts
@@ -15,7 +15,7 @@ export const postTransactionsSchema = {
       type: "string",
     },
   },
-  required: ["id", "stellar_memo", "stellar_memo_type", "stellar_memo"],
+  required: ["id"],
   additionalProperties: false,
 };
 
@@ -87,13 +87,7 @@ export const getTransactionSchema = {
           type: "boolean",
         },
       },
-      required: [
-        "id",
-        "status",
-        "stellar_account_id",
-        "stellar_memo",
-        "stellar_memo_type",
-      ],
+      required: ["id", "status"],
     },
   },
   required: ["transaction"],

--- a/@stellar/anchor-tests/src/tests/sep31/transactions.ts
+++ b/@stellar/anchor-tests/src/tests/sep31/transactions.ts
@@ -255,7 +255,9 @@ const canCreateTransaction: Test = {
       return result;
     }
     try {
-      Keypair.fromPublicKey(responseBody.stellar_account_id);
+      if (responseBody.stellar_account_id) {
+        Keypair.fromPublicKey(responseBody.stellar_account_id);
+      }
     } catch {
       result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
         errors: "'stellar_acocunt_id' must be a valid Stellar public key",
@@ -267,7 +269,9 @@ const canCreateTransaction: Test = {
       memoValue = Buffer.from(responseBody.stellar_memo, "base64");
     }
     try {
-      new Memo(responseBody.stellar_memo_type, memoValue);
+      if (memoValue) {
+        new Memo(responseBody.stellar_memo_type, memoValue);
+      }
     } catch {
       result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
         errors: "invalid 'stellar_memo' for 'stellar_memo_type'",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.12"
+    "@stellar/anchor-tests": "0.6.13"
   }
 }


### PR DESCRIPTION
`stellar_account_id`, `stellar_memo`, and `stellar_memo_type` are optional in the POST `/transaction` response and the GET `/transaction` schema.