### PR TITLE
Fix SEP-31 transaction validation with quote

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep31/transactions.ts
+++ b/@stellar/anchor-tests/src/tests/sep31/transactions.ts
@@ -260,7 +260,7 @@ const canCreateTransaction: Test = {
       }
     } catch {
       result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
-        errors: "'stellar_acocunt_id' must be a valid Stellar public key",
+        errors: "'stellar_account_id' must be a valid Stellar public key",
       });
       return result;
     }

--- a/@stellar/anchor-tests/src/tests/sep31And38/transactions.ts
+++ b/@stellar/anchor-tests/src/tests/sep31And38/transactions.ts
@@ -128,10 +128,12 @@ const canCreateTransaction: Test = {
       return result;
     }
     try {
-      Keypair.fromPublicKey(responseBody.stellar_account_id);
+      if (responseBody.stellar_account_id) {
+        Keypair.fromPublicKey(responseBody.stellar_account_id);
+      }
     } catch {
       result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
-        errors: "'stellar_acocunt_id' must be a valid Stellar public key",
+        errors: "'stellar_account_id' must be a valid Stellar public key",
       });
       return result;
     }
@@ -140,7 +142,9 @@ const canCreateTransaction: Test = {
       memoValue = Buffer.from(responseBody.stellar_memo, "base64");
     }
     try {
-      new Memo(responseBody.stellar_memo_type, memoValue);
+      if (memoValue) {
+        new Memo(responseBody.stellar_memo_type, memoValue);
+      }
     } catch {
       result.failure = makeFailure(this.failureModes.INVALID_SCHEMA, {
         errors: "invalid 'stellar_memo' for 'stellar_memo_type'",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.13"
+    "@stellar/anchor-tests": "0.6.14"
   }
 }


### PR DESCRIPTION
A previous PR removed the requirement of `stellar_account_id`, `stellar_memo`, and `stellar_memo_type` for SEP-31 transactions. This PR removes the same requirement when the SEP-31 transaction is created with a quote.