### PR TITLE
Make npm publish idempotent

### DIFF
--- a/.github/workflows/npm_and_docker_publish.yml
+++ b/.github/workflows/npm_and_docker_publish.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Depencencies
         run: yarn install
@@ -23,6 +23,7 @@ jobs:
         run: yarn build:all
 
       - name: Publish npm package
+        continue-on-error: true
         run: yarn publish:anchor-tests
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -32,6 +33,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install Latest npm Package
+        run: yarn add anchor-tests@latest
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4.0.0


### PR DESCRIPTION
The `stellar/anchor-tests:v0.6.14` image uses the `0.6.13` npm package. According to GitHub Copilot, this is a consequence of Docker's caching mechanism and can be fixed by installing the latest version of the npm package first.

Since the npm package has already been published, this PR also allows the `npm publish` step to continue on error so we can rerun the job temporarily. This part will be reverted after the `0.6.14` image is fixed.