### PR TITLE
Install to package workspace root

### DIFF
--- a/.github/workflows/npm_and_docker_publish.yml
+++ b/.github/workflows/npm_and_docker_publish.yml
@@ -35,7 +35,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install Latest npm Package
-        run: yarn add anchor-tests@latest
+        run: yarn add anchor-tests@latest -W
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4.0.0


### PR DESCRIPTION
This fixes the following error when installing the latest version in the build.

```
Run yarn add anchor-tests@latest
yarn add v1.22.22
error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
```