### PR TITLE
Fix Dockerfile and remove build step

### DIFF
--- a/.github/workflows/npm_and_docker_publish.yml
+++ b/.github/workflows/npm_and_docker_publish.yml
@@ -34,9 +34,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Install Latest npm Package
-        run: yarn add @stellar/anchor-tests@latest -W
-
       - name: Build and push Docker images
         uses: docker/build-push-action@v4.0.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN npm install -g typescript &&  \
 WORKDIR /code
 
 COPY . .
-RUN npm install -g @stellar/anchor-tests
+RUN yarn install
+RUN yarn build:anchor-tests
 
-ENTRYPOINT ["stellar-anchor-tests"]
+ENTRYPOINT ["yarn", "stellar-anchor-tests"]


### PR DESCRIPTION
```
docker build . -t philip/stellar-anchor-tests

[+] Building 43.9s (12/12) FINISHED                                                                                                                                                                        docker:orbstack
 => [internal] load build definition from Dockerfile                                                                                                                                                                  0.0s
 => => transferring dockerfile: 373B                                                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/node:20                                                                                                                                                            0.2s
 => [internal] load .dockerignore                                                                                                                                                                                     0.0s
 => => transferring context: 122B                                                                                                                                                                                     0.0s
 => [1/7] FROM docker.io/library/node:20@sha256:d3c8ababe9566f9f3495d0d365a5c4b393f607924647dd52e75bf4f8a54effd3                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                     0.1s
 => => transferring context: 201.11kB                                                                                                                                                                                 0.1s
 => CACHED [2/7] RUN node --version &&      npm --version &&      yarn --version                                                                                                                                      0.0s
 => CACHED [3/7] RUN npm install -g typescript &&      tsc --version                                                                                                                                                  0.0s
 => CACHED [4/7] WORKDIR /code                                                                                                                                                                                        0.0s
 => [5/7] COPY . .                                                                                                                                                                                                    0.2s
 => [6/7] RUN yarn install                                                                                                                                                                                           36.0s
 => [7/7] RUN yarn build:anchor-tests                                                                                                                                                                                 2.1s
 => exporting to image                                                                                                                                                                                                5.0s
 => => exporting layers                                                                                                                                                                                               5.0s
 => => writing image sha256:0a1f671e357360babb254e0862a6c4f956a521f45522af02fd089d5ba077dc61                                                                                                                          0.0s
 => => naming to docker.io/philip/stellar-anchor-tests                                                                                                                                                                0.0s
docker run philip/stellar-anchor-tests --version
yarn run v1.22.22
$ node @stellar/anchor-tests/lib/cli.js --version
0.6.14
Done in 0.11s.
```