### PR TITLE
Remove continue-on-error in npm publish

### DIFF
--- a/.github/workflows/npm_and_docker_publish.yml
+++ b/.github/workflows/npm_and_docker_publish.yml
@@ -23,7 +23,6 @@ jobs:
         run: yarn build:all
 
       - name: Publish npm package
-        continue-on-error: true
         run: yarn publish:anchor-tests
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The `0.6.14` has been fixed, continuing on error is no longer necessary in the `npm publish` step.