### PR TITLE
[ANCHOR-809] Add `funding_method` to SEP-6/31 infoSchema

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/schemas/sep31.ts
+++ b/@stellar/anchor-tests/src/schemas/sep31.ts
@@ -94,26 +94,6 @@ export const getTransactionSchema = {
   additionalProperties: false,
 };
 
-const fieldsSchema = {
-  type: "object",
-  additionalProperties: {
-    type: "object",
-    properties: {
-      description: {
-        type: "string",
-      },
-      optional: {
-        type: "boolean",
-      },
-      choices: {
-        type: "array",
-      },
-    },
-    required: ["description"],
-    additionalProperties: false,
-  },
-};
-
 export const infoSchema = {
   type: "object",
   properties: {
@@ -122,10 +102,90 @@ export const infoSchema = {
       additionalProperties: {
         type: "object",
         properties: {
-          enabled: { type: "boolean" },
-          min_amount: { type: "number" },
-          max_amount: { type: "number" },
-          fields: fieldsSchema,
+          enabled: {
+            type: "boolean",
+          },
+          fee_fixed: {
+            type: "number",
+          },
+          fee_percent: {
+            type: "number",
+          },
+          min_amount: {
+            type: "number",
+          },
+          max_amount: {
+            type: "number",
+          },
+          funding_method: {
+            type: "array",
+          },
+          sep12: {
+            type: "object",
+            properties: {
+              sender: {
+                type: "object",
+                properties: {
+                  types: {
+                    type: "object",
+                    additionalProperties: {
+                      type: "object",
+                      properties: {
+                        description: {
+                          type: "string",
+                        },
+                      },
+                      required: ["description"],
+                    },
+                  },
+                },
+              },
+              receiver: {
+                type: "object",
+                properties: {
+                  types: {
+                    type: "object",
+                    additionalProperties: {
+                      type: "object",
+                      properties: {
+                        description: {
+                          type: "string",
+                        },
+                      },
+                      required: ["description"],
+                    },
+                  },
+                },
+              },
+            },
+            required: ["sender", "receiver"],
+            additionalProperties: false,
+          },
+          fields: {
+            type: "object",
+            properties: {
+              transaction: {
+                type: "object",
+                additionalProperties: {
+                  type: "object",
+                  properties: {
+                    description: {
+                      type: "string",
+                    },
+                    optional: {
+                      type: "boolean",
+                    },
+                    choices: {
+                      type: "array",
+                    },
+                  },
+                  required: ["description"],
+                },
+              },
+            },
+            required: ["transaction"],
+            additionalProperties: false,
+          },
         },
       },
     },

--- a/@stellar/anchor-tests/src/schemas/sep31.ts
+++ b/@stellar/anchor-tests/src/schemas/sep31.ts
@@ -94,6 +94,26 @@ export const getTransactionSchema = {
   additionalProperties: false,
 };
 
+const fieldsSchema = {
+  type: "object",
+  additionalProperties: {
+    type: "object",
+    properties: {
+      description: {
+        type: "string",
+      },
+      optional: {
+        type: "boolean",
+      },
+      choices: {
+        type: "array",
+      },
+    },
+    required: ["description"],
+    additionalProperties: false,
+  },
+};
+
 export const infoSchema = {
   type: "object",
   properties: {
@@ -102,87 +122,10 @@ export const infoSchema = {
       additionalProperties: {
         type: "object",
         properties: {
-          enabled: {
-            type: "boolean",
-          },
-          fee_fixed: {
-            type: "number",
-          },
-          fee_percent: {
-            type: "number",
-          },
-          min_amount: {
-            type: "number",
-          },
-          max_amount: {
-            type: "number",
-          },
-          sep12: {
-            type: "object",
-            properties: {
-              sender: {
-                type: "object",
-                properties: {
-                  types: {
-                    type: "object",
-                    additionalProperties: {
-                      type: "object",
-                      properties: {
-                        description: {
-                          type: "string",
-                        },
-                      },
-                      required: ["description"],
-                    },
-                  },
-                },
-              },
-              receiver: {
-                type: "object",
-                properties: {
-                  types: {
-                    type: "object",
-                    additionalProperties: {
-                      type: "object",
-                      properties: {
-                        description: {
-                          type: "string",
-                        },
-                      },
-                      required: ["description"],
-                    },
-                  },
-                },
-              },
-            },
-            required: ["sender", "receiver"],
-            additionalProperties: false,
-          },
-          fields: {
-            type: "object",
-            properties: {
-              transaction: {
-                type: "object",
-                additionalProperties: {
-                  type: "object",
-                  properties: {
-                    description: {
-                      type: "string",
-                    },
-                    optional: {
-                      type: "boolean",
-                    },
-                    choices: {
-                      type: "array",
-                    },
-                  },
-                  required: ["description"],
-                },
-              },
-            },
-            required: ["transaction"],
-            additionalProperties: false,
-          },
+          enabled: { type: "boolean" },
+          min_amount: { type: "number" },
+          max_amount: { type: "number" },
+          fields: fieldsSchema,
         },
       },
     },

--- a/@stellar/anchor-tests/src/schemas/sep6.ts
+++ b/@stellar/anchor-tests/src/schemas/sep6.ts
@@ -30,6 +30,7 @@ const depositInfoSchema = {
         min_amount: { type: "number" },
         max_amount: { type: "number" },
         authentication_required: { type: "boolean" },
+        funding_method: { type: "array" },
         fields: fieldsSchema,
       },
       required: ["enabled"],
@@ -50,6 +51,7 @@ const withdrawInfoSchema = {
         min_amount: { type: "number" },
         max_amount: { type: "number" },
         authentication_required: { type: "boolean" },
+        funding_method: { type: "array" },
         types: {
           additionalProperties: {
             type: "object",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.16"
+    "@stellar/anchor-tests": "0.6.17"
   }
 }


### PR DESCRIPTION
Part of ticket https://stellarorg.atlassian.net/browse/ANCHOR-809
The response should looks like:
```
  {
    "receive": {
      "JPYC": {
        "enabled": true,
        "quotes_supported": true,
        "quotes_required": false,
        "min_amount": 0,
        "max_amount": 1000000,
        "funding_method": ["SEPA", "SWIFT"],
        "fields": { ... }
      },
      "USDC": {
        "enabled": true,
        "quotes_supported": true,
        "quotes_required": false,
        "min_amount": 0,
        "max_amount": 10, 
        "funding_method": ["SEPA", "SWIFT"],
        "fields": { ... }
      }
    }
  }
```