### PR TITLE
[ANCHOR-809][SEP-6] Fix `/info` test logic

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep6/info.ts
+++ b/@stellar/anchor-tests/src/tests/sep6/info.ts
@@ -276,13 +276,11 @@ const requiredDepositFieldsMatchConfiguration: Test = {
     const depositFieldKeys = Object.keys(
       config.sepConfig["6"].deposit.transactionFields,
     );
-    for (const configuredKey of depositFieldKeys) {
-      if (
-        !this.context.expects.sep6DepositFieldsRequired.includes(configuredKey)
-      ) {
+    for (const requiredKey of this.context.expects.sep6DepositFieldsRequired) {
+      if (depositFieldKeys.includes(requiredKey)) {
         result.failure = makeFailure(this.failureModes.FIELD_NOT_FOUND);
-        result.expected = configuredKey;
-        result.actual = this.context.expects.sep6DepositFieldsRequired;
+        result.expected = requiredKey;
+        result.actual = depositFieldKeys;
         return result;
       }
     }

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.19"
+    "@stellar/anchor-tests": "0.6.20"
   }
 }


### PR DESCRIPTION
The correct logic should be checking all of the required keys are provided.
Instead of checking if any provided keys is not required.

This also fix the validation test error in https://github.com/stellar/java-stellar-anchor-sdk/actions/runs/12057359373/job/33621982173?pr=1582