### PR TITLE
Prevent exposing secrets on config modal

### DIFF
--- a/ui/src/components/ConfigModalContent/index.tsx
+++ b/ui/src/components/ConfigModalContent/index.tsx
@@ -172,7 +172,7 @@ export const ConfigModalContent: React.FC = () => (
             publicKey:
               "GDTW75HOEQFPAMZ7YTFRN2TMVLVBXK7QYC4AJMXISV2WLD7E7RSZTDIA",
             secretKey:
-              "SAMISXU66LL2QDOP3A4EEKIEV4BV7EG3BJYFR65OF6WBOM6IQTDQOKWG",
+              "SBDR...GVEO",
           },
           depositPendingTransaction: {
             id: "252062",
@@ -283,7 +283,7 @@ export const ConfigModalContent: React.FC = () => (
       <Json
         src={{
           sendingAnchorClientSecret:
-            "SB7E7M6VLBXXIEDJ4RXP7E4SS4CFDMFMIMWERJVY3MSRGNN5ROANA5OJ",
+            "SBE6...NDTM",
           sendingClientName: "sendingClient",
           receivingClientName: "receivingClient",
           transactionFields: {},


### PR DESCRIPTION
Prevent exposing secrets on the "UPLOAD CONFIG" modal instructions for Sep-24 and Sep-31.

We have no accounts created on those secrets, but let's hide them to prevent being exploited in the future. 

<img width="1299" alt="Screenshot 2025-06-11 at 11 10 23" src="https://github.com/user-attachments/assets/a505663b-5afd-4dc6-82f3-8477b5e33d86" />
<img width="1306" alt="Screenshot 2025-06-11 at 11 10 46" src="https://github.com/user-attachments/assets/6aa70c17-401d-4323-a0ab-b2a58d07d272" />
