### PR TITLE
[ANCHOR-1025] Fix sep31 sep38 tests for xlm

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/tests/sep31/info.ts
+++ b/@stellar/anchor-tests/src/tests/sep31/info.ts
@@ -111,24 +111,35 @@ export const hasExpectedAssetEnabled: Test = {
   },
   async run(config: Config): Promise<Result> {
     const result: Result = { networkCalls: [] };
-    // Always pick the first enabled asset from SEP-31's /info response
-    // Don't reuse previously selected assets from other SEPs
-    let selectedAssetCode: string | undefined;
-    for (const assetCode in this.context.expects.sep31InfoObj.receive) {
-      if (this.context.expects.sep31InfoObj.receive[assetCode].enabled) {
-        selectedAssetCode = assetCode;
-        break;
+    if (!config.assetCode) {
+      for (const assetCode in this.context.expects.sep31InfoObj.receive) {
+        if (this.context.expects.sep31InfoObj.receive[assetCode].enabled) {
+          config.assetCode = assetCode;
+          break;
+        }
+      }
+      if (!config.assetCode) {
+        result.failure = makeFailure(this.failureModes.NO_ASSET_CODES);
+        return result;
       }
     }
-
-    if (!selectedAssetCode) {
-      result.failure = makeFailure(this.failureModes.NO_ASSET_CODES);
+    if (
+      !Object.keys(this.context.expects.sep31InfoObj.receive).includes(
+        config.assetCode,
+      )
+    ) {
+      result.failure = makeFailure(this.failureModes.ASSET_NOT_FOUND, {
+        assetCode: config.assetCode,
+      });
+      return result;
+    } else if (
+      !this.context.expects.sep31InfoObj.receive[config.assetCode].enabled
+    ) {
+      result.failure = makeFailure(this.failureModes.ASSET_CODE_NOT_ENABLED, {
+        assetCode: config.assetCode,
+      });
       return result;
     }
-
-    // Set the asset code for SEP-31 tests
-    config.assetCode = selectedAssetCode;
-
     return result;
   },
 };
@@ -137,7 +148,7 @@ const hasExpectedTransactionFields: Test = {
   assertion: "check optional transaction 'fields'",
   sep: 31,
   group: "GET /info",
-  dependencies: [hasExpectedAssetEnabled],
+  dependencies: [hasValidInfoSchema],
   context: {
     expects: {
       sep31InfoObj: undefined,
@@ -173,20 +184,10 @@ const hasExpectedTransactionFields: Test = {
       // this is checked before tests are run
       throw new Error("improperly configured");
     const result: Result = { networkCalls: [] };
-
-    // Ensure the asset exists in the receive object before accessing its fields
-    const assetInfo =
-      this.context.expects.sep31InfoObj.receive[config.assetCode];
-    if (!assetInfo) {
-      // This should not happen if hasExpectedAssetEnabled ran successfully,
-      // but adding this check for safety
-      throw new Error(
-        `Asset ${config.assetCode} not found in SEP-31 info response`,
-      );
-    }
-
-    if (assetInfo.fields) {
-      const responseTransactionFields = assetInfo.fields.transaction;
+    if (this.context.expects.sep31InfoObj.receive[config.assetCode].fields) {
+      const responseTransactionFields =
+        this.context.expects.sep31InfoObj.receive[config.assetCode].fields
+          .transaction;
       const responseTransactionFieldNames = Object.keys(
         responseTransactionFields,
       );

--- a/@stellar/anchor-tests/src/tests/sep38/prices.ts
+++ b/@stellar/anchor-tests/src/tests/sep38/prices.ts
@@ -121,7 +121,6 @@ export const hasValidSchema: Test = {
     }
     for (const asset of pricesResponse.buy_assets) {
       const parts = asset.asset.split(":");
-      
       const notValidFiat = parts.length === 2 && parts[0] !== "iso4217";
       const notValidStellar = parts.length === 3 && parts[0] !== "stellar";
       const notValidAtAll = parts.length < 2 || parts.length > 3;
@@ -251,12 +250,17 @@ export const allowsOffChainSellAssets: Test = {
         this.failureModes.INVALID_ASSET_VALUE,
         { asset: asset.asset },
       );
-      if (parts.length !== 3 || parts[0] !== "stellar") {
+
+      const isNativeAsset = asset.asset === "stellar:native";
+      const isValidOnChainAsset = parts.length === 3 && parts[0] === "stellar";
+      if (!isNativeAsset && !isValidOnChainAsset) {
         result.failure = invalidAssetFailure;
         return result;
       }
       try {
-        Keypair.fromPublicKey(parts[2]);
+        if (!isNativeAsset) {
+          Keypair.fromPublicKey(parts[2]);
+        }
       } catch {
         result.failure = invalidAssetFailure;
         return result;

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,6 @@
     "winston": "^3.3.3"
   },
   "peerDependencies": {
-    "@stellar/anchor-tests": "0.6.20"
+    "@stellar/anchor-tests": "0.6.21"
   }
 }


### PR DESCRIPTION
This PR fix (https://github.com/stellar/anchor-platform/actions/runs/16782100286/job/47523704900?pr=1780)
```
✖ SEP-31 ‣ GET /info ‣ has expected asset enabled
  Failure Type: expected asset not found
  Description: The /info response body does not contain information for native

✖ SEP-31 ‣ GET /info ‣ check optional transaction 'fields'
  Failure Type: unexpected exception  
  Description: Cannot read properties of undefined (reading 'fields')
  
✖ SEP-38 ‣ GET /prices ‣ allows off-chain assets as 'sell_asset'
Failure Type: invalid 'asset' value
Description: The 'asset' value stellar:native does not comply with SEP-38 Asset Identification Format
```

Root Cause: 
SEP-31: stellar-anchor-tests were trying to use the same assetCode (`native` in my case) for all tests. But with https://github.com/stellar/anchor-platform/pull/1780 `native` is only enabled for SEP-6 and SEP-24 and can't be find in `/sep31/info`, ~~thus changing the logic to use the first SEP-31 enabled assetCode~~ This can be fixed by setting `--asset-code` through cli

SEP-38: native asset fomat issue


Testing: 
 yarn build:anchor-tests && yarn stellar-anchor-tests --home-domain http://localhost:8080 --seps 1 6 10 12 24 31 38 --sep-config $SEP_CONFIG --asset-code USDC && echo SUCCESS!