### PR TITLE
[ANCHOR-1215] Use id-type memos for SEP-12/SEP-31 customer auth

### DIFF
--- a/@stellar/anchor-tests/package.json
+++ b/@stellar/anchor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/anchor-tests",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "description": "stellar-anchor-tests is a library and command line interface for testing Stellar anchors.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/@stellar/anchor-tests/src/helpers/sep10.ts
+++ b/@stellar/anchor-tests/src/helpers/sep10.ts
@@ -222,13 +222,16 @@ export async function getChallenge(
   webAuthEndpoint: string,
   networkPassphrase: string,
   result: Result,
+  memo?: string,
 ): Promise<Transaction | void> {
   if (!webAuthEndpoint) {
     result.failure = makeFailure(getChallengeFailureModes.NO_WEB_AUTH_ENDPOINT);
     return;
   }
+  let challengeUrl = webAuthEndpoint + `?account=${accountAddress}`;
+  if (memo) challengeUrl += `&memo=${memo}`;
   const getAuthCall: NetworkCall = {
-    request: new Request(webAuthEndpoint + `?account=${accountAddress}`),
+    request: new Request(challengeUrl),
   };
   result.networkCalls.push(getAuthCall);
   try {
@@ -296,6 +299,7 @@ export async function postChallenge(
   result: Result,
   useJson: boolean = false,
   challenge?: Transaction,
+  memo?: string,
 ): Promise<string | void> {
   if (!challenge) {
     challenge = (await getChallenge(
@@ -303,6 +307,7 @@ export async function postChallenge(
       webAuthEndpoint,
       networkPassphrase,
       result,
+      memo,
     )) as Transaction;
     if (!challenge) return;
     challenge.sign(clientKeypair);
@@ -377,7 +382,19 @@ export async function postChallenge(
     return;
   }
   try {
-    Keypair.fromPublicKey(jwtContents.sub);
+    // SEP-10 JWT sub may be "<account>" or "<account>:<memo_id>" where
+    // <memo_id> is a uint64 (digits only). Validate the account portion via
+    // Keypair.fromPublicKey (handles G/M/C addresses) and require the memo
+    // suffix, if present, to be all digits.
+    const colonIdx = jwtContents.sub.indexOf(":");
+    const subAccount =
+      colonIdx >= 0 ? jwtContents.sub.substring(0, colonIdx) : jwtContents.sub;
+    const memoPart =
+      colonIdx >= 0 ? jwtContents.sub.substring(colonIdx + 1) : null;
+    if (memoPart !== null && !/^\d+$/.test(memoPart)) {
+      throw new Error("invalid memo suffix in JWT sub");
+    }
+    Keypair.fromPublicKey(subAccount);
   } catch {
     result.failure = makeFailure(postChallengeFailureModes.INVALID_JWT_SUB);
     return;

--- a/@stellar/anchor-tests/src/tests/sep12/putCustomer.ts
+++ b/@stellar/anchor-tests/src/tests/sep12/putCustomer.ts
@@ -1,7 +1,6 @@
 import fetch from "node-fetch";
 import { Request, BodyInit } from "node-fetch";
 import { Keypair, Memo } from "stellar-sdk";
-import { randomBytes } from "crypto";
 
 import { Test, Config, Result, NetworkCall } from "../../types";
 import { returnsValidJwt } from "../sep10/tests";
@@ -186,6 +185,7 @@ export const differentMemosSameAccount: Test = {
     provides: {
       sendingAnchorClientKeypair: undefined,
       sendingAnchorToken: undefined,
+      receivingAnchorToken: undefined,
       sendingCustomerId: undefined,
       sendingCustomerMemo: undefined,
       receivingCustomerId: undefined,
@@ -279,25 +279,36 @@ export const differentMemosSameAccount: Test = {
         ];
       this.context.provides.sendingAnchorClientKeypair = Keypair.random();
     }
-    this.context.provides.sendingCustomerMemo = Memo.hash(
-      randomBytes(32).toString("hex"),
-    );
-    this.context.provides.receivingCustomerMemo = Memo.hash(
-      randomBytes(32).toString("hex"),
-    );
+    // Use id-type memos so the memo can be carried in the SEP-10 JWT sub.
+    // SEP-10 only supports id-type memos; hash/text memos cannot be encoded in
+    // the JWT, so they can't satisfy SEP-12's (account, memo) auth model.
+    const sendingMemoId = "1";
+    const receivingMemoId = "2";
+    this.context.provides.sendingCustomerMemo = Memo.id(sendingMemoId);
+    this.context.provides.receivingCustomerMemo = Memo.id(receivingMemoId);
     this.context.provides.sendingAnchorToken = await postChallenge(
       this.context.provides.sendingAnchorClientKeypair,
       this.context.expects.webAuthEndpoint,
       this.context.expects.tomlObj.NETWORK_PASSPHRASE,
       result,
+      false,
+      undefined,
+      sendingMemoId,
+    );
+    this.context.provides.receivingAnchorToken = await postChallenge(
+      this.context.provides.sendingAnchorClientKeypair,
+      this.context.expects.webAuthEndpoint,
+      this.context.expects.tomlObj.NETWORK_PASSPHRASE,
+      result,
+      false,
+      undefined,
+      receivingMemoId,
     );
     const sep12Request = makeSep12Request({
       url: this.context.expects.kycServerUrl + "/customer",
       data: {
-        memo: this.context.provides.sendingCustomerMemo.value.toString(
-          "base64",
-        ),
-        memo_type: "hash",
+        memo: sendingMemoId,
+        memo_type: "id",
         ...sendingCustomerData,
       },
       headers: {
@@ -326,14 +337,12 @@ export const differentMemosSameAccount: Test = {
     const receivingCustomerRequest = makeSep12Request({
       url: this.context.expects.kycServerUrl + "/customer",
       data: {
-        memo: this.context.provides.receivingCustomerMemo.value.toString(
-          "base64",
-        ),
-        memo_type: "hash",
+        memo: receivingMemoId,
+        memo_type: "id",
         ...receivingCustomerData,
       },
       headers: {
-        Authorization: `Bearer ${this.context.provides.sendingAnchorToken}`,
+        Authorization: `Bearer ${this.context.provides.receivingAnchorToken}`,
       },
     });
     const receivingCustomerCall: NetworkCall = {

--- a/@stellar/anchor-tests/src/tests/sep31/transactions.ts
+++ b/@stellar/anchor-tests/src/tests/sep31/transactions.ts
@@ -68,6 +68,7 @@ const canCreateTransaction: Test = {
       kycServerUrl: undefined,
       sendingAnchorClientKeypair: undefined,
       sendingAnchorToken: undefined,
+      receivingAnchorToken: undefined,
       sendingCustomerId: undefined,
       receivingCustomerId: undefined,
       sep31InfoObj: undefined,
@@ -139,15 +140,11 @@ const canCreateTransaction: Test = {
       kycServerUrl: string,
       customerId: string,
       token: string,
+      customerType: string | undefined,
     ): NetworkCall {
       const requestParamsObj: Record<string, string> = {
         id: customerId,
       };
-
-      const customerType =
-        config?.sepConfig?.["12"]?.customers?.[
-          config?.sepConfig?.["12"]?.createCustomer
-        ].type;
 
       if (customerType) requestParamsObj["type"] = customerType;
       const searchParams = new URLSearchParams(requestParamsObj);
@@ -165,16 +162,30 @@ const canCreateTransaction: Test = {
       return getCustomerCall;
     }
 
+    const sendingCustomerType =
+      config?.sepConfig?.["12"]?.customers?.[
+        config?.sepConfig?.["31"]?.sendingClientName ?? ""
+      ]?.type;
+
+    const receivingCustomerType =
+      config?.sepConfig?.["12"]?.customers?.[
+        config?.sepConfig?.["31"]?.receivingClientName ?? ""
+      ]?.type;
+
+    // Each customer must be polled with the token whose JWT sub matches its
+    // (account, memo) — SEP-12 binds customer identity to the SEP-10 caller.
     const getSendingCustomerNetworkCall = generateGetCustomerNetworkCall(
       this.context.expects.kycServerUrl,
       this.context.expects.sendingCustomerId,
       this.context.expects.sendingAnchorToken,
+      sendingCustomerType,
     );
 
     const getReceivingCustomerNetworkCall = generateGetCustomerNetworkCall(
       this.context.expects.kycServerUrl,
       this.context.expects.receivingCustomerId,
-      this.context.expects.sendingAnchorToken,
+      this.context.expects.receivingAnchorToken,
+      receivingCustomerType,
     );
 
     const customerPollingTimeout =


### PR DESCRIPTION
Companion change to stellar/anchor-platform#1946 (https://github.com/stellar/anchor-platform/pull/1946), which closes a SEP-12 IDOR where any SEP-10–authenticated caller could GET or PUT another customer's KYC record by supplying the victim's id. The AP fix enforces that customer access via id matches the SEP-10 token's (account, memo).

#### Why the existing tests broke

  Two test paths were relying on AP's pre-fix (vulnerable) behavior:
  
  1. **SEP-12 › PUT /customer › memos differentiate customers registered by the same account** — created two customers under the same sender account distinguished by `Memo.hash(randomBytes(32))` random hash memos. SEP-10 JWTs can only carry id-type memos in their sub (per the spec). Once AP starts enforcing `(account, memo)` ownership against the token, hash-memo customers can't be authenticated for id-path access — the reverse-lookup can never find them.
  2. **SEP-31 › POST /transactions › can create a transaction** — polled both sender and receiver customer status using the same `sendingAnchorToken` (no memo). With the AP fix, each customer must be polled with a token whose JWT sub matches that customer's storage key.

  Per SEP-12 spec ([§memo_type](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md)), "memos should always be of type id" — non-id memo types are deprecated. The tests were exercising a deprecated pattern that the AP fix no longer permits.

#### What changed
  
1. `src/helpers/sep10.ts` — add optional `memo` parameter to `getChallenge` and `postChallenge`; append `&memo=...` to the challenge URL; relax JWT sub validation to accept `G_X:memo` format (strip the `:memo` suffix before `Keypair.fromPublicKey()`).
2. `src/tests/sep12/putCustomer.ts` (SEP-31 path) — replace `Memo.hash(randomBytes(32))` with `Memo.id("1")` /
  `Memo.id("2")`; generate two SEP-10 tokens from the same sender keypair (one with `memo=1`, one with `memo=2`); PUT sender customer with the memo-1 token, receiver customer with the memo-2 token; store both tokens in context.
3. `src/tests/sep31/transactions.ts` — the receiver polling call uses `receivingAnchorToken` instead of `sendingAnchorToken`; each customer is polled with the token whose JWT sub matches its storage key.

#### Testing
  
  Run against a local anchor-platform with stellar/anchor-platform#1946 (reverse-lookup variant) applied:
  ```
  yarn build:anchor-tests && \
  yarn stellar-anchor-tests \
    --home-domain http://localhost:8080 \
    --seps 1 6 10 12 31 38 \
    --asset-code USDC \
    --sep-config /path/to/stellar-anchor-tests-sep-config.json
```
  Result: 94 passed, 4 skipped, 0 failed.

#### Known limitations
  
The hash- and text-type memo paths for SEP-12 customer registration are no longer exercised by this test suite after this change. The original `differentMemosSameAccount` test was the only place that exercised `memo_type=hash`.

  This is intentional and aligned with the SEP-12 spec, which deprecates non-id memo types:
  

> memo_type … Deprecated because memos should always be of type id, although anchors should continue to support this parameter for outdated clients. — SEP-12 [§memo_type](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md)

  SEP-10 JWTs can only encode id-type memos in their `sub`, so any anchor that enforces `(account, memo)` ownership against the token (as anchor-platform now does for the id path) cannot authenticate access to customers stored under hash- or text-type memos. Anchors still supporting hash/text memos for backwards-compat will continue to work for their account-keyed and `transaction_id`-keyed access paths, but id-path access for those customers is by design no longer available.

  If/when SEP-31 adoption picks up and a real anchor needs hash-memo SEP-12 coverage, the path forward is either to migrate those anchors to id-type memos (spec-aligned) or to add a separate test that authenticates via the `transaction_id` path.